### PR TITLE
Fix workflow syntax error and remove push triggers

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -5,12 +5,6 @@ on:
     # Run daily at 2 AM EST (7 AM UTC)
     - cron: '0 7 * * *'
   workflow_dispatch:  # Allow manual trigger
-  push:
-    branches:
-      - main
-    paths:
-      - 'data/**'
-      - 'tracking/public/data/**'
 
 # Needed for pushing changes back to repo and creating PRs
 permissions:
@@ -139,7 +133,8 @@ jobs:
           gh pr merge $PR_NUMBER --merge --auto
 
   deploy-to-prod:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && needs.update-data.result == 'success')
+    needs: update-data
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/daily-questionnaire-analysis.yml
+++ b/.github/workflows/daily-questionnaire-analysis.yml
@@ -5,11 +5,6 @@ on:
     # Run daily at 4 AM EST (9 AM UTC) - 2 hours after data update
     - cron: '0 9 * * *'
   workflow_dispatch:  # Allow manual trigger
-  push:
-    branches:
-      - main
-    paths:
-      - 'questionnaires/**'
 
 # Needed for pushing changes back to repo and creating PRs
 permissions:
@@ -145,7 +140,7 @@ jobs:
           gh pr merge $PR_NUMBER --merge --auto
         fi
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Pages
       uses: actions/configure-pages@v4
@@ -160,7 +155,8 @@ jobs:
       uses: actions/deploy-pages@v4
 
   deploy-to-prod:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && needs.analyze-questionnaires.result == 'success')
+    needs: analyze-questionnaires
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/update-job-data.yml
+++ b/.github/workflows/update-job-data.yml
@@ -5,11 +5,6 @@ on:
     # Run every Monday at 2 AM UTC
     - cron: '0 2 * * 1'
   workflow_dispatch: # Allow manual trigger
-  push:
-    branches:
-      - main
-    paths:
-      - 'tracking/public/data/**'
 
 # Needed for pushing changes back to repo and creating PRs
 permissions:
@@ -134,7 +129,8 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-to-prod:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && needs.update-data.result == 'success')
+    needs: update-data
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
- Fix missing closing bracket in GITHUB_TOKEN expression
- Remove push triggers from all workflows
- Deploy to prod branches only on schedule/manual trigger
- Use job dependencies to ensure deploy runs after successful update