### PR TITLE
Fix column names in data integrity tests and git push issue

### DIFF
--- a/update/test_data_integrity.py
+++ b/update/test_data_integrity.py
@@ -65,7 +65,7 @@ def check_data_recency(filepath, max_days_old, description):
         df = pd.read_parquet(filepath)
         
         # Check if there's a date column
-        date_columns = ['DatePosted', 'date_posted', 'PositionOpenDate', 'ApplicationCloseDate']
+        date_columns = ['DatePosted', 'date_posted', 'PositionOpenDate', 'ApplicationCloseDate', 'applicationCloseDate', 'positionOpenDate']
         date_col = None
         for col in date_columns:
             if col in df.columns:
@@ -100,7 +100,7 @@ def check_data_recency(filepath, max_days_old, description):
 
 def check_no_data_loss():
     """Ensure historical data hasn't been lost"""
-    baseline_file = '../data/data_baseline.json'
+    baseline_file = 'data_baseline.json'  # Store in update directory
     
     # If baseline doesn't exist, create it
     if not os.path.exists(baseline_file):
@@ -168,10 +168,10 @@ def check_data_consistency():
         historical_ids = set(historical_2025['PositionID'].unique()) if 'PositionID' in historical_2025.columns else set()
         
         # Check for control numbers if PositionID doesn't exist
-        if not current_ids and 'ControlNumber' in current_2025.columns:
-            current_ids = set(current_2025['ControlNumber'].unique())
-        if not historical_ids and 'ControlNumber' in historical_2025.columns:
-            historical_ids = set(historical_2025['ControlNumber'].unique())
+        if not current_ids and 'usajobsControlNumber' in current_2025.columns:
+            current_ids = set(current_2025['usajobsControlNumber'].unique())
+        if not historical_ids and 'usajobsControlNumber' in historical_2025.columns:
+            historical_ids = set(historical_2025['usajobsControlNumber'].unique())
         
         if current_ids and historical_ids:
             missing_in_historical = current_ids - historical_ids
@@ -199,8 +199,8 @@ def run_tests():
     print_header("1. CURRENT DATA FILES")
     
     current_files = [
-        ('current_jobs_2024.parquet', 100, ['PositionTitle', 'PositionLocation'], 'Current jobs 2024'),
-        ('current_jobs_2025.parquet', 100, ['PositionTitle', 'PositionLocation'], 'Current jobs 2025')
+        ('current_jobs_2024.parquet', 100, ['positionTitle', 'positionLocation'], 'Current jobs 2024'),
+        ('current_jobs_2025.parquet', 100, ['positionTitle', 'positionLocation'], 'Current jobs 2025')
     ]
     
     for filename, min_rows, cols, desc in current_files:
@@ -212,9 +212,9 @@ def run_tests():
     
     for year in range(2013, 2026):
         filename = f'historical_jobs_{year}.parquet'
-        min_rows = 10 if year < 2017 else 1000  # Early years have less data
+        min_rows = 5 if year < 2015 else 10 if year < 2017 else 1000  # Early years have less data
         if not check_parquet_file(f'../data/{filename}', min_rows, 
-                                   ['PositionTitle'], f'Historical jobs {year}'):
+                                   ['positionTitle'], f'Historical jobs {year}'):
             all_passed = False
     
     # Test 3: Data recency

--- a/update/update_all.py
+++ b/update/update_all.py
@@ -366,11 +366,18 @@ def commit_and_push_changes():
         print("ℹ️  No changes to commit or commit failed")
         return False
     
-    # Push to remote
-    success, _ = run_command("git push", "Pushing to remote repository")
+    # Get current branch name
+    success, branch_name = run_command("git rev-parse --abbrev-ref HEAD", "Getting current branch")
+    branch_name = branch_name.strip() if success else "main"
+    
+    # Push to remote (set upstream if needed)
+    success, _ = run_command(f"git push --set-upstream origin {branch_name}", "Pushing to remote repository")
     if not success:
-        print("❌ Failed to push to remote repository")
-        return False
+        # Try regular push if branch already exists
+        success, _ = run_command("git push", "Pushing to remote repository (retry)")
+        if not success:
+            print("❌ Failed to push to remote repository")
+            return False
     
     print("✅ Successfully committed and pushed changes")
     return True


### PR DESCRIPTION
- Update test to use actual column names (positionTitle not PositionTitle)
- Fix git push to use --set-upstream for new branches
- Adjust minimum row expectations for early years (2013 has only 5 rows)
- Store baseline in update directory instead of data directory