### PR TITLE
Remove labels from gh pr create commands

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -104,9 +104,7 @@ jobs:
             --base main \
             --head data-updates \
             --title "Daily data update - $(date +'%Y-%m-%d')" \
-            --body "Automated daily data update from USAJobs API" \
-            --label "automated" \
-            --label "data-update"
+            --body "Automated daily data update from USAJobs API"
         else
           echo "PR already exists, skipping creation"
         fi

--- a/.github/workflows/daily-questionnaire-analysis.yml
+++ b/.github/workflows/daily-questionnaire-analysis.yml
@@ -114,9 +114,7 @@ jobs:
             --base main \
             --head questionnaire-updates \
             --title "Questionnaire analysis update - $(date +'%Y-%m-%d')" \
-            --body "Automated questionnaire analysis update" \
-            --label "automated" \
-            --label "questionnaire-update"
+            --body "Automated questionnaire analysis update"
         else
           echo "PR already exists, skipping creation"
         fi

--- a/.github/workflows/update-job-data.yml
+++ b/.github/workflows/update-job-data.yml
@@ -98,9 +98,7 @@ jobs:
             --base main \
             --head tracking-updates \
             --title "Weekly tracking data update - $(date +'%Y-%m-%d')" \
-            --body "Automated weekly tracking data update" \
-            --label "automated" \
-            --label "tracking-update"
+            --body "Automated weekly tracking data update"
         else
           echo "PR already exists, skipping creation"
         fi


### PR DESCRIPTION
The workflows were failing because the labels don't exist in the repository. Removed --label flags to fix the error.

🤖 Generated with [Claude Code](https://claude.ai/code)