### PR TITLE
Use PAT_TOKEN instead of GITHUB_TOKEN for PR creation

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Create Pull Request
       if: env.CHANGES_MADE == 'true'
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PAT_TOKEN }}
       run: |
         # Check if PR already exists
         PR_EXISTS=$(gh pr list --base main --head data-updates --state open --json number --jq length)
@@ -123,7 +123,7 @@ jobs:
           gh pr merge $PR_NUMBER --merge --auto
         fi
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PAT_TOKEN }}
 
     - name: Check for failures
       if: failure() || (env.CHANGES_MADE == 'true' && steps.data_tests.outcome == 'failure')

--- a/.github/workflows/daily-questionnaire-analysis.yml
+++ b/.github/workflows/daily-questionnaire-analysis.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Create Pull Request
       if: env.CHANGES_MADE == 'true'
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PAT_TOKEN }}
       run: |
         # Check if PR already exists
         PR_EXISTS=$(gh pr list --base main --head questionnaire-updates --state open --json number --jq length)
@@ -133,7 +133,7 @@ jobs:
           gh pr merge $PR_NUMBER --merge --auto
         fi
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PAT_TOKEN }}
 
     - name: Setup Pages
       uses: actions/configure-pages@v4

--- a/.github/workflows/update-job-data.yml
+++ b/.github/workflows/update-job-data.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Create Pull Request
       if: env.CHANGES_MADE == 'true'
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PAT_TOKEN }}
       run: |
         # Check if PR already exists
         PR_EXISTS=$(gh pr list --base main --head tracking-updates --state open --json number --jq length)
@@ -117,7 +117,7 @@ jobs:
           gh pr merge $PR_NUMBER --merge --auto
         fi
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PAT_TOKEN }}
 
   deploy-to-prod:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && needs.update-data.result == 'success')


### PR DESCRIPTION
GitHub Actions default token doesn't have permission to create PRs. Updated all workflows to use PAT_TOKEN secret instead.

🤖 Generated with [Claude Code](https://claude.ai/code)