### PR TITLE
Tune repoll: 15 workers, biweekly rotation

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -137,27 +137,33 @@ jobs:
       env:
         GITHUB_ACTIONS: true
       run: |
-        # Determine which years to re-poll based on day of the week
-        # Always poll recent data (last 6 months): current year + previous year
+        # Always poll recent data: current year + previous year
         CURRENT_YEAR=$(date +'%Y')
         PREV_YEAR=$((CURRENT_YEAR - 1))
         YEARS="$PREV_YEAR $CURRENT_YEAR"
 
-        # Rotate through older years across the workweek (Mon=1 .. Fri=5)
-        DOW=$(date +%u)
-        case $DOW in
-          1) YEARS="2013 2014 2015 2016 $YEARS" ;;  # Monday
-          2) YEARS="2017 2018 $YEARS" ;;              # Tuesday
-          3) YEARS="2019 2020 $YEARS" ;;              # Wednesday
-          4) YEARS="2021 2022 $YEARS" ;;              # Thursday
-          5) YEARS="2023 $YEARS" ;;                   # Friday
-          *) ;;  # Weekend: just recent years
-        esac
+        # Older years rotate on a biweekly schedule using ISO week number.
+        # Two groups alternate every other week:
+        #
+        # Odd weeks (1,3,5,...):  2013-2016 + 2019-2020  (~26 + 709 = ~735 dates)
+        #   - 2013-2016: tiny, ~257 dates total (mostly resolved)
+        #   - 2019-2020: ~709 dates, ~148k non-final jobs
+        #
+        # Even weeks (2,4,6,...): 2017-2018 + 2021-2023  (~719 + 1054 = ~1773 dates)
+        #   - 2017-2018: ~719 dates, ~229k non-final jobs
+        #   - 2021-2023: ~1054 dates, ~120k non-final jobs
+        #
+        WEEK=$(date +%V)
+        if [ $((WEEK % 2)) -eq 1 ]; then
+          YEARS="2013 2014 2015 2016 2019 2020 $YEARS"
+        else
+          YEARS="2017 2018 2021 2022 2023 $YEARS"
+        fi
 
-        # Remove duplicates (e.g. if CURRENT_YEAR is already in the rotation)
+        # Remove duplicates
         YEARS=$(echo $YEARS | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
-        echo "Day of week: $DOW"
+        echo "ISO week: $WEEK ($([ $((WEEK % 2)) -eq 1 ] && echo 'odd' || echo 'even'))"
         echo "Re-polling years: $YEARS"
         python scripts/repoll_status.py --years $YEARS
 

--- a/scripts/repoll_status.py
+++ b/scripts/repoll_status.py
@@ -149,7 +149,7 @@ def main():
     parser = argparse.ArgumentParser(description="Re-poll status for non-final historical jobs")
     parser.add_argument("--years", nargs="*", type=int, help="Specific years to re-poll (default: all)")
     parser.add_argument("--dry-run", action="store_true", help="Just count dates, don't query API")
-    parser.add_argument("--workers", type=int, default=10, help="Parallel API workers (default: 10)")
+    parser.add_argument("--workers", type=int, default=15, help="Parallel API workers (default: 15)")
     args = parser.parse_args()
 
     # Find all historical parquet files


### PR DESCRIPTION
## Summary
- Bump parallel API workers from 10 to 15
- Switch older year rotation from daily (day-of-week) to biweekly (ISO week):
  - **Odd weeks**: 2013-2016 + 2019-2020 (~735 dates)
  - **Even weeks**: 2017-2018 + 2021-2023 (~1773 dates)
- Current + previous year still polled every day

## Test plan
- [ ] Verify workflow runs within 120 min timeout
- [ ] Confirm 15 workers doesn't trigger API rate limiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)