### PR TITLE
Add Pivot & Counts page with downloadable group-by tables

### DIFF
--- a/web/api/pivot.py
+++ b/web/api/pivot.py
@@ -1,0 +1,186 @@
+"""Pivot / counts endpoint.
+
+Groups the (deduplicated) job listings by any number of selected dimensions
+and returns the counts in long / tidy format — one row per combination of
+dimension values, plus a Count column. Reuses the same `filter_*` query
+params as every other endpoint, so callers can filter first and pivot the
+filtered subset.
+
+Examples:
+  /api/pivot?dims=department,year
+  /api/pivot?dims=agency,grade&filter_status=open
+  /api/pivot?dims=series&format=csv          (streams a CSV download)
+
+Dimension column order in the output follows the order given in `dims`.
+
+Note on multi-value dimensions (series, location): a single listing can carry
+several occupational series or locations (stored as a '; '-delimited list).
+Selecting one of those dimensions unnests the list, so a listing is counted
+once per value it carries — the same semantics as the occupational-series
+chart on the main page. With no multi-value dimension selected, Count is a
+clean count of distinct listings (the data is already deduplicated to one row
+per usajobsControlNumber).
+"""
+
+import csv
+import io
+import json
+from http.server import BaseHTTPRequestHandler
+from urllib.parse import urlparse, parse_qs
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(__file__))
+from data_loader import get_parquet_path, get_conn
+from columns import parse_filters
+
+# key -> (header label, single-value SQL expression, multi-value source column)
+# Exactly one of (expr, multi_col) is set. For multi_col the value list is
+# split on '; ' and unnested.
+DIMENSIONS = {
+    'department':      ('Department',       'COALESCE(CAST("hiringDepartmentName" AS VARCHAR), \'Unknown\')', None),
+    'agency':          ('Agency',           'COALESCE(CAST("hiringAgencyName" AS VARCHAR), \'Unknown\')', None),
+    'year':            ('Year',             'strftime(CAST("openDate" AS DATE), \'%Y\')', None),
+    'month':           ('Month',            'strftime(CAST("openDate" AS DATE), \'%Y-%m\')', None),
+    'grade':           ('Grade',            'COALESCE(CAST("grade" AS VARCHAR), \'Unknown\')', None),
+    'appointmentType': ('Appointment Type', 'COALESCE(CAST("appointmentType" AS VARCHAR), \'Unknown\')', None),
+    'serviceType':     ('Service',          'COALESCE(CAST("serviceType" AS VARCHAR), \'Unknown\')', None),
+    'status':          ('Status',           'COALESCE(CAST("status" AS VARCHAR), \'Unknown\')', None),
+    'series':          ('Occ. Series',      None, 'occupationalSeries'),
+    'location':        ('Location',         None, 'locations'),
+}
+
+MAX_DIMS = 6            # cap dimensions to keep the grid from exploding
+MAX_PREVIEW_ROWS = 500  # rows returned to the on-page preview
+MAX_CSV_ROWS = 200000   # safety cap on a CSV download
+
+
+def _build_query(dims, where_sql):
+    """Build the pivot SQL for the given ordered dimension keys.
+
+    Returns (sql, headers). The SQL ends without LIMIT so the caller appends one.
+    """
+    parquet_path = get_parquet_path()
+
+    selects = []        # "<expr> AS d0"
+    lateral_joins = []   # ", LATERAL (...) AS s0"
+    group_cols = []      # "d0"
+    nonempty = []        # "d0 <> ''"  (multi-value dims only)
+    headers = []
+
+    for i, key in enumerate(dims):
+        label, expr, multi_col = DIMENSIONS[key]
+        alias = f'd{i}'
+        headers.append(label)
+        group_cols.append(alias)
+        if multi_col:
+            join_alias = f's{i}'
+            lateral_joins.append(
+                f", LATERAL (SELECT TRIM(unnest(string_split("
+                f"CAST(\"{multi_col}\" AS VARCHAR), '; '))) AS v) AS {join_alias}"
+            )
+            selects.append(f"{join_alias}.v AS {alias}")
+            nonempty.append(f"{alias} <> ''")
+        else:
+            selects.append(f"{expr} AS {alias}")
+
+    inner = (
+        f"SELECT {', '.join(selects)} "
+        f"FROM read_parquet('{parquet_path}') AS t"
+        f"{''.join(lateral_joins)} "
+        f"{where_sql}"
+    )
+
+    outer_where = f"WHERE {' AND '.join(nonempty)} " if nonempty else ''
+    sql = (
+        f"SELECT {', '.join(group_cols)}, COUNT(*) AS cnt "
+        f"FROM ({inner}) sub "
+        f"{outer_where}"
+        f"GROUP BY {', '.join(group_cols)} "
+        f"ORDER BY cnt DESC, {', '.join(group_cols)}"
+    )
+    return sql, headers
+
+
+class handler(BaseHTTPRequestHandler):
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.end_headers()
+
+    def _send_json(self, status, obj):
+        body = json.dumps(obj).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Cache-Control', 'public, max-age=300')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        try:
+            parsed = urlparse(self.path)
+            params = parse_qs(parsed.query)
+
+            raw_dims = params.get('dims', [''])[0]
+            dims = [d.strip() for d in raw_dims.split(',') if d.strip()]
+
+            if not dims:
+                self._send_json(400, {'error': 'dims is required, e.g. dims=department,year'})
+                return
+            bad = [d for d in dims if d not in DIMENSIONS]
+            if bad:
+                self._send_json(400, {
+                    'error': f'unknown dimension(s): {", ".join(bad)}',
+                    'allowed': list(DIMENSIONS.keys()),
+                })
+                return
+            if len(dims) > MAX_DIMS:
+                self._send_json(400, {'error': f'at most {MAX_DIMS} dimensions allowed'})
+                return
+
+            want_csv = params.get('format', [''])[0] == 'csv'
+            limit = MAX_CSV_ROWS if want_csv else MAX_PREVIEW_ROWS + 1
+
+            filter_clauses, bind_values = parse_filters(params)
+            where_sql = f'WHERE {" AND ".join(filter_clauses)}' if filter_clauses else ''
+
+            sql, headers = _build_query(dims, where_sql)
+            sql += f' LIMIT {limit}'
+
+            conn = get_conn()
+            rows = conn.execute(sql, bind_values).fetchall()
+            conn.close()
+
+            if want_csv:
+                buf = io.StringIO()
+                writer = csv.writer(buf)
+                writer.writerow(headers + ['Count'])
+                writer.writerows(rows)
+                csv_bytes = buf.getvalue().encode('utf-8')
+
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/csv; charset=utf-8')
+                self.send_header('Content-Disposition', 'attachment; filename="usajobs_pivot.csv"')
+                self.send_header('Access-Control-Allow-Origin', '*')
+                self.send_header('Content-Length', str(len(csv_bytes)))
+                self.end_headers()
+                self.wfile.write(csv_bytes)
+                return
+
+            truncated = len(rows) > MAX_PREVIEW_ROWS
+            if truncated:
+                rows = rows[:MAX_PREVIEW_ROWS]
+
+            self._send_json(200, {
+                'headers': headers + ['Count'],
+                'rows': [list(r) for r in rows],
+                'truncated': truncated,
+                'preview_limit': MAX_PREVIEW_ROWS,
+            })
+
+        except Exception as e:
+            self._send_json(500, {'error': str(e)})

--- a/web/index.html
+++ b/web/index.html
@@ -27,6 +27,8 @@
             <h1>USAJobs Data</h1>
             <p class="site-subtitle">Federal job postings from 2018 to present</p>
             <nav class="site-nav" style="margin-top:0.6rem;font-size:0.95rem;">
+                <a href="pivot.html" style="font-weight:600;color:#2d6e4e;">Pivot &amp; counts</a>
+                <span style="margin:0 0.4rem;color:#C9BCA8;">|</span>
                 Posters:
                 <a href="poster.html" style="margin-left:0.4rem;font-weight:600;color:#2d6e4e;">Postings</a>
                 &middot;
@@ -119,7 +121,7 @@
 
         <!-- Footer -->
         <footer class="site-footer">
-            <p><a href="poster.html">Postings</a> &middot; <a href="accessions-poster.html">Accessions</a> &middot; <a href="workforce-flow.html">Workforce flow</a> &middot; <a href="workforce-pathways.html">Pathways</a> &middot; <a href="overlay-poster.html">Postings vs accessions</a> &middot; Data from <a href="https://developer.usajobs.gov/">USAJobs API</a> &middot; Code on <a href="https://github.com/abigailhaddad/usajobs_historical">GitHub</a> &middot; Built by <a href="https://abigailhaddad.netlify.app">Abigail Haddad</a></p>
+            <p><a href="pivot.html">Pivot &amp; counts</a> &middot; <a href="poster.html">Postings</a> &middot; <a href="accessions-poster.html">Accessions</a> &middot; <a href="workforce-flow.html">Workforce flow</a> &middot; <a href="workforce-pathways.html">Pathways</a> &middot; <a href="overlay-poster.html">Postings vs accessions</a> &middot; Data from <a href="https://developer.usajobs.gov/">USAJobs API</a> &middot; Code on <a href="https://github.com/abigailhaddad/usajobs_historical">GitHub</a> &middot; Built by <a href="https://abigailhaddad.netlify.app">Abigail Haddad</a></p>
         </footer>
     </div>
 

--- a/web/pivot.html
+++ b/web/pivot.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pivot &amp; Counts — USAJobs Data</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="shared/shared.css">
+    <style>
+        .pivot-builder {
+            background: #fff;
+            border: 1px solid #E8DDD0;
+            border-radius: 10px;
+            padding: 1.1rem 1.25rem;
+            margin-bottom: 1.25rem;
+        }
+        .pivot-builder h2 {
+            font-size: 1.05rem;
+            margin: 0 0 0.25rem;
+        }
+        .pivot-builder .hint {
+            color: #7A6E62;
+            font-size: 0.9rem;
+            margin-bottom: 0.85rem;
+        }
+        .dim-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem 0.8rem;
+        }
+        .dim-option {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.35rem 0.6rem;
+            border: 1px solid #E8DDD0;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.92rem;
+            user-select: none;
+        }
+        .dim-option:hover { background: #FBF7F0; }
+        .dim-option input { cursor: pointer; }
+        .dim-option .order-badge {
+            display: inline-block;
+            min-width: 1.25rem;
+            text-align: center;
+            background: #2D6A4F;
+            color: #fff;
+            border-radius: 4px;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0 0.25rem;
+        }
+        .dim-option .multi-note { color: #B07A1E; font-size: 0.78rem; }
+        .pivot-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            margin-top: 1rem;
+            flex-wrap: wrap;
+        }
+        .pivot-result-meta { color: #7A6E62; font-size: 0.9rem; }
+        .pivot-table-wrapper { overflow-x: auto; margin-top: 0.5rem; }
+        table.pivot-table { border-collapse: collapse; width: 100%; font-size: 0.92rem; }
+        table.pivot-table th, table.pivot-table td {
+            border-bottom: 1px solid #EFE7DA;
+            padding: 0.4rem 0.7rem;
+            text-align: left;
+            white-space: nowrap;
+        }
+        table.pivot-table th { background: #FBF7F0; font-weight: 600; }
+        table.pivot-table td.count-col, table.pivot-table th.count-col {
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+        }
+        .pivot-empty { color: #7A6E62; padding: 0.75rem 0; }
+    </style>
+</head>
+<body>
+    <div class="site-container">
+        <header class="site-header">
+            <h1>Pivot &amp; Counts</h1>
+            <p class="site-subtitle">Count federal job listings grouped by any combination of fields — then download the table</p>
+            <nav class="site-nav" style="margin-top:0.6rem;font-size:0.95rem;">
+                <a href="index.html" style="font-weight:600;color:#2d6e4e;">&larr; Back to data</a>
+            </nav>
+        </header>
+
+        <!-- Filters (reuses the same filter machinery as the main page) -->
+        <div id="toolbarButtons" class="toolbar-row"></div>
+        <div class="filters-bar-container">
+            <div class="filters-bar" id="filtersBar">
+                <span class="filters-bar-empty">No filters applied</span>
+            </div>
+        </div>
+
+        <!-- Pivot builder -->
+        <div class="pivot-builder">
+            <h2>Group by</h2>
+            <p class="hint">
+                Pick one or more fields. Counts are shown for every combination, ordered by count.
+                Fields marked <span style="color:#B07A1E;">(counts each)</span> let a listing carry
+                several values, so it is counted once per value.
+            </p>
+            <div class="dim-grid" id="dimGrid"></div>
+
+            <div class="pivot-actions">
+                <button class="csv-download-btn" id="downloadBtn" disabled>Download CSV</button>
+                <span class="pivot-result-meta" id="resultMeta"></span>
+            </div>
+        </div>
+
+        <div class="pivot-table-wrapper">
+            <div id="pivotResult" class="pivot-empty">Select a field above to build a pivot table.</div>
+        </div>
+
+        <footer class="site-footer">
+            <p><a href="index.html">Data</a> &middot; Data from <a href="https://developer.usajobs.gov/">USAJobs API</a> &middot; Code on <a href="https://github.com/abigailhaddad/usajobs_historical">GitHub</a> &middot; Built by <a href="https://abigailhaddad.netlify.app">Abigail Haddad</a></p>
+        </footer>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="shared/shared.js"></script>
+    <script>
+        const API_BASE = '';
+        window.API_BASE = API_BASE;
+
+        // Dimensions the pivot endpoint accepts. `multi` flags '; '-delimited
+        // fields where one listing can carry several values.
+        const DIMENSIONS = [
+            { key: 'department',      label: 'Department' },
+            { key: 'agency',          label: 'Agency' },
+            { key: 'year',            label: 'Year (open date)' },
+            { key: 'month',           label: 'Month (open date)' },
+            { key: 'grade',           label: 'Grade' },
+            { key: 'appointmentType', label: 'Appointment type' },
+            { key: 'serviceType',     label: 'Service' },
+            { key: 'status',          label: 'Status' },
+            { key: 'series',          label: 'Occupational series', multi: true },
+            { key: 'location',        label: 'Location', multi: true }
+        ];
+
+        // Filter config — same fields/types the main jobs table uses, so the
+        // shared ServerSideFilterManager (filter bar UI + URL sync) just works.
+        const FILTER_COLUMNS = [
+            { name: 'Position Title', field: 'positionTitle', filterType: 'text', index: 0 },
+            { name: 'Occ. Series', field: 'occupationalSeries', filterType: 'multiselect', index: 1 },
+            { name: 'Department', field: 'hiringDepartmentName', filterType: 'multiselect', index: 2 },
+            { name: 'Agency', field: 'hiringAgencyName', filterType: 'multiselect', index: 3 },
+            { name: 'Grade', field: 'grade', filterType: 'multiselect', index: 4 },
+            { name: 'Min Salary', field: 'minimumSalary', filterType: 'range', index: 5, format: 'currency' },
+            { name: 'Max Salary', field: 'maximumSalary', filterType: 'range', index: 6, format: 'currency' },
+            { name: 'Open Date', field: 'openDate', filterType: 'daterange', index: 7 },
+            { name: 'Close Date', field: 'closeDate', filterType: 'daterange', index: 8 },
+            { name: 'Appointment Type', field: 'appointmentType', filterType: 'multiselect', index: 9 },
+            { name: 'Service', field: 'serviceType', filterType: 'multiselect', index: 10 },
+            { name: 'Locations', field: 'locations', filterType: 'text', index: 11 },
+            { name: 'Status', field: 'status', filterType: 'multiselect', index: 12 }
+        ];
+
+        // Selected dimension keys, in the order the user picked them.
+        let selectedDims = [];
+        let filterManager = null;
+
+        function buildDimGrid() {
+            const grid = document.getElementById('dimGrid');
+            DIMENSIONS.forEach(function (dim) {
+                const label = document.createElement('label');
+                label.className = 'dim-option';
+                label.dataset.key = dim.key;
+
+                const cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.value = dim.key;
+                cb.addEventListener('change', function () { onDimToggle(dim.key, cb.checked); });
+
+                const badge = document.createElement('span');
+                badge.className = 'order-badge';
+                badge.style.display = 'none';
+
+                const text = document.createElement('span');
+                text.textContent = dim.label;
+
+                label.appendChild(cb);
+                label.appendChild(badge);
+                label.appendChild(text);
+                if (dim.multi) {
+                    const note = document.createElement('span');
+                    note.className = 'multi-note';
+                    note.textContent = '(counts each)';
+                    label.appendChild(note);
+                }
+                grid.appendChild(label);
+            });
+        }
+
+        function onDimToggle(key, checked) {
+            if (checked) {
+                if (selectedDims.indexOf(key) === -1) selectedDims.push(key);
+            } else {
+                selectedDims = selectedDims.filter(function (k) { return k !== key; });
+            }
+            updateOrderBadges();
+            writeDimsToUrl();
+            runPivot();
+        }
+
+        // The shared filter manager owns the filter params in the URL (it rewrites
+        // the whole query string on every filter change). We layer the `dims`
+        // param on top so a shared link reproduces both the filters and the
+        // group-by selection.
+        function writeDimsToUrl() {
+            const url = new URL(window.location.href);
+            if (selectedDims.length > 0) {
+                url.searchParams.set('dims', selectedDims.join(','));
+            } else {
+                url.searchParams.delete('dims');
+            }
+            window.history.replaceState({}, '', url);
+        }
+
+        function restoreDimsFromUrl() {
+            const raw = new URLSearchParams(window.location.search).get('dims') || '';
+            const keys = raw.split(',').map(function (k) { return k.trim(); }).filter(Boolean);
+            const valid = DIMENSIONS.map(function (d) { return d.key; });
+            selectedDims = keys.filter(function (k) { return valid.indexOf(k) !== -1; });
+            selectedDims.forEach(function (k) {
+                const cb = document.querySelector('.dim-option[data-key="' + k + '"] input');
+                if (cb) cb.checked = true;
+            });
+            updateOrderBadges();
+        }
+
+        function updateOrderBadges() {
+            document.querySelectorAll('.dim-option').forEach(function (el) {
+                const pos = selectedDims.indexOf(el.dataset.key);
+                const badge = el.querySelector('.order-badge');
+                if (pos === -1) {
+                    badge.style.display = 'none';
+                } else {
+                    badge.style.display = 'inline-block';
+                    badge.textContent = pos + 1;
+                }
+            });
+        }
+
+        function currentQueryString() {
+            const filterQs = filterManager ? filterManager.getFilterQueryString() : '';
+            const parts = ['dims=' + encodeURIComponent(selectedDims.join(','))];
+            if (filterQs) parts.push(filterQs);
+            return parts.join('&');
+        }
+
+        async function runPivot() {
+            const result = document.getElementById('pivotResult');
+            const meta = document.getElementById('resultMeta');
+            const downloadBtn = document.getElementById('downloadBtn');
+
+            if (selectedDims.length === 0) {
+                result.className = 'pivot-empty';
+                result.textContent = 'Select a field above to build a pivot table.';
+                meta.textContent = '';
+                downloadBtn.disabled = true;
+                return;
+            }
+
+            result.className = 'pivot-empty';
+            result.textContent = 'Loading…';
+            meta.textContent = '';
+
+            try {
+                const resp = await fetch(API_BASE + '/api/pivot?' + currentQueryString());
+                const data = await resp.json();
+                if (data.error) {
+                    result.textContent = 'Error: ' + data.error;
+                    downloadBtn.disabled = true;
+                    return;
+                }
+                renderTable(data);
+                downloadBtn.disabled = data.rows.length === 0;
+            } catch (e) {
+                result.textContent = 'Error loading pivot: ' + e;
+                downloadBtn.disabled = true;
+            }
+        }
+
+        function renderTable(data) {
+            const result = document.getElementById('pivotResult');
+            const meta = document.getElementById('resultMeta');
+
+            if (data.rows.length === 0) {
+                result.className = 'pivot-empty';
+                result.textContent = 'No rows match the current filters.';
+                meta.textContent = '';
+                return;
+            }
+
+            const lastCol = data.headers.length - 1;
+            let html = '<table class="pivot-table"><thead><tr>';
+            data.headers.forEach(function (h, i) {
+                html += '<th class="' + (i === lastCol ? 'count-col' : '') + '">' + escapeHtml(h) + '</th>';
+            });
+            html += '</tr></thead><tbody>';
+            data.rows.forEach(function (row) {
+                html += '<tr>';
+                row.forEach(function (cell, i) {
+                    if (i === lastCol) {
+                        html += '<td class="count-col">' + formatNumber(cell) + '</td>';
+                    } else {
+                        html += '<td>' + escapeHtml(cell == null ? '' : String(cell)) + '</td>';
+                    }
+                });
+                html += '</tr>';
+            });
+            html += '</tbody></table>';
+
+            result.className = '';
+            result.innerHTML = html;
+
+            if (data.truncated) {
+                meta.textContent = 'Showing the top ' + formatNumber(data.preview_limit) +
+                    ' rows. Download the CSV for the full table.';
+            } else {
+                meta.textContent = formatNumber(data.rows.length) + ' rows.';
+            }
+        }
+
+        function downloadCsv() {
+            if (selectedDims.length === 0) return;
+            window.location.href = API_BASE + '/api/pivot?format=csv&' + currentQueryString();
+        }
+
+        document.addEventListener('DOMContentLoaded', function () {
+            buildDimGrid();
+
+            filterManager = new ServerSideFilterManager({
+                columns: FILTER_COLUMNS,
+                filterBarId: 'filtersBar',
+                syncURL: true,
+                // The manager rewrites the URL with the filter params *before*
+                // calling this, so we re-add `dims` afterward to keep both.
+                onFilterChange: function () {
+                    writeDimsToUrl();
+                    runPivot();
+                }
+            });
+            // No DataTable on this page — init(null) just wires up the filter bar.
+            filterManager.init(null);
+
+            document.getElementById('downloadBtn').addEventListener('click', downloadCsv);
+
+            // Restore group-by + filters from the URL so a shared link reproduces
+            // the whole pivot. (The manager already restored filters in its ctor.)
+            restoreDimsFromUrl();
+            if (selectedDims.length > 0) runPivot();
+        });
+    </script>
+</body>
+</html>

--- a/web/tests/test_api.py
+++ b/web/tests/test_api.py
@@ -619,3 +619,97 @@ class TestExactMatchDropdownFilters:
         b = self._filtered_total("/api/jobs?length=1&filter_positionTitle=scientist")
         either = self._filtered_total("/api/jobs?length=1&filter_positionTitle=engineer,scientist")
         assert either >= max(a, b), "Comma-OR search should match at least as many as either term alone"
+
+
+# ===================================================================
+# Pivot endpoint (/api/pivot)
+# ===================================================================
+
+from api import pivot as pivot_mod
+
+
+def _invoke_csv(handler_class, path):
+    """Invoke a handler and return (status, raw_bytes) without JSON parsing."""
+    instance = object.__new__(handler_class)
+    instance.path = path
+    instance.command = "GET"
+    instance.headers = {}
+    buf = io.BytesIO()
+    instance.wfile = buf
+    captured = {"status": None}
+    instance.send_response = lambda code, msg=None: captured.__setitem__("status", code)
+    instance.send_header = lambda k, v: None
+    instance.end_headers = lambda: None
+    instance.log_message = lambda *a: None
+    instance.do_GET()
+    return captured["status"], buf.getvalue()
+
+
+class TestPivot:
+    """Tests for the /api/pivot long-format counts endpoint."""
+
+    def test_single_dimension(self):
+        status, body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=department")
+        assert status == 200
+        assert body["headers"] == ["Department", "Count"]
+        assert len(body["rows"]) > 0
+        # ordered by count desc
+        counts = [r[-1] for r in body["rows"]]
+        assert counts == sorted(counts, reverse=True)
+
+    def test_multi_dimension_order_preserved(self):
+        status, body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=department,year")
+        assert status == 200
+        assert body["headers"] == ["Department", "Year", "Count"]
+        assert all(len(r) == 3 for r in body["rows"])
+
+    def test_count_equals_distinct_listings_for_single_value_dim(self):
+        """With no multi-value dim, the pivot total must equal the row count
+        of the filtered set (data is deduped to one row per control number)."""
+        _, pivot_body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=status")
+        pivot_total = sum(r[-1] for r in pivot_body["rows"])
+        # /api/jobs reports the filtered total via recordsFiltered
+        _, jobs_body = _invoke_handler(jobs_mod.handler, "/api/jobs?length=1")
+        assert pivot_total == jobs_body["recordsTotal"]
+
+    def test_multi_value_dim_counts_each(self):
+        """A multi-value dim (series) should count a listing once per series,
+        so its total is >= the distinct listing count."""
+        _, series_body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=series")
+        series_total = sum(r[-1] for r in series_body["rows"])
+        _, jobs_body = _invoke_handler(jobs_mod.handler, "/api/jobs?length=1")
+        assert series_total >= jobs_body["recordsTotal"]
+        # no empty series labels leak through
+        assert all(r[0].strip() != "" for r in series_body["rows"])
+
+    def test_filters_apply(self):
+        status, body = _invoke_handler(
+            pivot_mod.handler,
+            "/api/pivot?dims=grade&filter_hiringDepartmentName=Department%20of%20Veterans%20Affairs",
+        )
+        assert status == 200
+        assert len(body["rows"]) > 0
+
+    def test_missing_dims_is_400(self):
+        status, body = _invoke_handler(pivot_mod.handler, "/api/pivot")
+        assert status == 400
+        assert "dims" in body["error"]
+
+    def test_unknown_dim_is_400(self):
+        status, body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=nonsense")
+        assert status == 400
+
+    def test_too_many_dims_is_400(self):
+        status, body = _invoke_handler(
+            pivot_mod.handler,
+            "/api/pivot?dims=department,agency,year,month,grade,status,serviceType",
+        )
+        assert status == 400
+
+    def test_csv_download(self):
+        status, raw = _invoke_csv(pivot_mod.handler, "/api/pivot?dims=department&format=csv")
+        assert status == 200
+        text = raw.decode("utf-8")
+        lines = text.splitlines()
+        assert lines[0] == "Department,Count"
+        assert len(lines) > 1


### PR DESCRIPTION
## What

A new **/pivot** page where anyone can count federal job listings grouped by any combination of fields and download the result as CSV. Already deployed to production: https://usajobs-historical.vercel.app/pivot.html

## How it works

- **`web/api/pivot.py`** — new endpoint. Dynamic `GROUP BY` over any number (≤6) of selected dimensions, reusing the shared `parse_filters`. Returns long/tidy JSON (top-500 preview) or a full CSV when `format=csv`.
  - Dimensions: department, agency, year, month, grade, appointment type, service, status, occupational series, location.
  - Multi-value fields (occ series, location are `; `-delimited) are unnested so a listing is counted once per value — labeled **(counts each)** in the UI, matching the existing series chart semantics.
  - With no multi-value dim, `COUNT(*)` == distinct listings (data is deduped to one row per `usajobsControlNumber` in `prep_web_data.py`).
- **`web/pivot.html`** — dimension picker (selection order = column order), reuses the shared `ServerSideFilterManager` filter bar so you can **filter first, then pivot**. Preview table + Download CSV.
  - **Shareable URLs**: the URL embeds both the filters and a `dims=` param, so a copied link reproduces the entire pivot (filters + group-by). Verified the round-trip in a browser.
- **`web/index.html`** — links the new page from nav + footer.

## Tests

Added `TestPivot` (9 cases): single/multi dimension, column ordering, dedup count identity (`sum(counts) == recordsTotal`), multi-value counts-each, filters, CSV output, and the 400 validations. Full suite green — **55 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)