### PR TITLE
Fix pivot multi-value (series/location) counting + location crash

### DIFF
--- a/web/api/pivot.py
+++ b/web/api/pivot.py
@@ -13,13 +13,21 @@ Examples:
 
 Dimension column order in the output follows the order given in `dims`.
 
-Note on multi-value dimensions (series, location): a single listing can carry
-several occupational series or locations (stored as a '; '-delimited list).
-Selecting one of those dimensions unnests the list, so a listing is counted
-once per value it carries — the same semantics as the occupational-series
-chart on the main page. With no multi-value dimension selected, Count is a
-clean count of distinct listings (the data is already deduplicated to one row
-per usajobsControlNumber).
+Multi-value dimensions (series, location)
+-----------------------------------------
+A single listing can carry several occupational series or locations (stored
+as a '; '-delimited list). Selecting one of those dimensions unnests the list
+so the listing is counted once in EVERY value it actually has — e.g. a posting
+open in DC and Atlanta is counted under both. Counts therefore will NOT sum to
+the total number of listings; that is intentional and the UI flags it.
+
+The Count is always the number of DISTINCT listings in a group (we count
+distinct usajobsControlNumber), so a listing that happens to repeat a value
+in its own list is still only counted once for that value.
+
+To keep the result well-defined (and fast), at most ONE multi-value dimension
+may be used per pivot; combining two would produce a meaningless positional
+zip of the two lists.
 """
 
 import csv
@@ -34,9 +42,9 @@ sys.path.insert(0, os.path.dirname(__file__))
 from data_loader import get_parquet_path, get_conn
 from columns import parse_filters
 
-# key -> (header label, single-value SQL expression, multi-value source column)
+# key -> (header label, single-value SQL expression, multi-value source column).
 # Exactly one of (expr, multi_col) is set. For multi_col the value list is
-# split on '; ' and unnested.
+# split on '; ', unnested, and counted with COUNT(DISTINCT control number).
 DIMENSIONS = {
     'department':      ('Department',       'COALESCE(CAST("hiringDepartmentName" AS VARCHAR), \'Unknown\')', None),
     'agency':          ('Agency',           'COALESCE(CAST("hiringAgencyName" AS VARCHAR), \'Unknown\')', None),
@@ -50,6 +58,8 @@ DIMENSIONS = {
     'location':        ('Location',         None, 'locations'),
 }
 
+CONTROL = '"usajobsControlNumber"'
+
 MAX_DIMS = 6            # cap dimensions to keep the grid from exploding
 MAX_PREVIEW_ROWS = 500  # rows returned to the on-page preview
 MAX_CSV_ROWS = 200000   # safety cap on a CSV download
@@ -59,43 +69,50 @@ def _build_query(dims, where_sql):
     """Build the pivot SQL for the given ordered dimension keys.
 
     Returns (sql, headers). The SQL ends without LIMIT so the caller appends one.
+    Assumes at most one multi-value dimension (validated by the caller).
     """
     parquet_path = get_parquet_path()
+    headers = [DIMENSIONS[k][0] for k in dims]
+    group_cols = [f'd{i}' for i in range(len(dims))]
 
-    selects = []        # "<expr> AS d0"
-    lateral_joins = []   # ", LATERAL (...) AS s0"
-    group_cols = []      # "d0"
-    nonempty = []        # "d0 <> ''"  (multi-value dims only)
-    headers = []
+    multi_idx = next((i for i, k in enumerate(dims) if DIMENSIONS[k][2]), None)
 
-    for i, key in enumerate(dims):
-        label, expr, multi_col = DIMENSIONS[key]
-        alias = f'd{i}'
-        headers.append(label)
-        group_cols.append(alias)
-        if multi_col:
-            join_alias = f's{i}'
-            lateral_joins.append(
-                f", LATERAL (SELECT TRIM(unnest(string_split("
-                f"CAST(\"{multi_col}\" AS VARCHAR), '; '))) AS v) AS {join_alias}"
+    if multi_idx is None:
+        # All single-value: the data is one row per listing, so COUNT(*) is the
+        # exact distinct-listing count and we can group directly.
+        selects = [f'{DIMENSIONS[k][1]} AS d{i}' for i, k in enumerate(dims)]
+        sql = (
+            f"SELECT {', '.join(selects)}, COUNT(*) AS cnt "
+            f"FROM read_parquet('{parquet_path}') "
+            f"{where_sql} "
+            f"GROUP BY {', '.join(group_cols)} "
+            f"ORDER BY cnt DESC, {', '.join(group_cols)}"
+        )
+        return sql, headers
+
+    # One multi-value dimension: unnest its list in a flat subquery, keep the
+    # control number, then COUNT(DISTINCT control) so each listing is counted
+    # once per value it actually carries.
+    multi_col = DIMENSIONS[dims[multi_idx]][2]
+    inner_selects = [f'{CONTROL} AS _cn']
+    for i, k in enumerate(dims):
+        if i == multi_idx:
+            inner_selects.append(
+                f"TRIM(unnest(string_split(CAST(\"{multi_col}\" AS VARCHAR), '; '))) AS d{i}"
             )
-            selects.append(f"{join_alias}.v AS {alias}")
-            nonempty.append(f"{alias} <> ''")
         else:
-            selects.append(f"{expr} AS {alias}")
+            inner_selects.append(f'{DIMENSIONS[k][1]} AS d{i}')
 
     inner = (
-        f"SELECT {', '.join(selects)} "
-        f"FROM read_parquet('{parquet_path}') AS t"
-        f"{''.join(lateral_joins)} "
+        f"SELECT {', '.join(inner_selects)} "
+        f"FROM read_parquet('{parquet_path}') "
         f"{where_sql}"
     )
-
-    outer_where = f"WHERE {' AND '.join(nonempty)} " if nonempty else ''
+    multi_alias = f'd{multi_idx}'
     sql = (
-        f"SELECT {', '.join(group_cols)}, COUNT(*) AS cnt "
+        f"SELECT {', '.join(group_cols)}, COUNT(DISTINCT _cn) AS cnt "
         f"FROM ({inner}) sub "
-        f"{outer_where}"
+        f"WHERE {multi_alias} IS NOT NULL AND {multi_alias} <> '' "
         f"GROUP BY {', '.join(group_cols)} "
         f"ORDER BY cnt DESC, {', '.join(group_cols)}"
     )
@@ -142,6 +159,15 @@ class handler(BaseHTTPRequestHandler):
                 self._send_json(400, {'error': f'at most {MAX_DIMS} dimensions allowed'})
                 return
 
+            multi = [d for d in dims if DIMENSIONS[d][2]]
+            if len(multi) > 1:
+                self._send_json(400, {
+                    'error': 'pick at most one multi-value field (occupational series or '
+                             'location) at a time',
+                    'multi_value_fields': multi,
+                })
+                return
+
             want_csv = params.get('format', [''])[0] == 'csv'
             limit = MAX_CSV_ROWS if want_csv else MAX_PREVIEW_ROWS + 1
 
@@ -180,6 +206,7 @@ class handler(BaseHTTPRequestHandler):
                 'rows': [list(r) for r in rows],
                 'truncated': truncated,
                 'preview_limit': MAX_PREVIEW_ROWS,
+                'multi_value_dims': multi,
             })
 
         except Exception as e:

--- a/web/pivot.html
+++ b/web/pivot.html
@@ -78,6 +78,17 @@
             font-variant-numeric: tabular-nums;
         }
         .pivot-empty { color: #7A6E62; padding: 0.75rem 0; }
+        .multi-note-banner {
+            display: none;
+            margin-top: 0.9rem;
+            padding: 0.6rem 0.8rem;
+            background: #FBF1DD;
+            border: 1px solid #E7CF9E;
+            border-radius: 6px;
+            color: #7A5B16;
+            font-size: 0.9rem;
+        }
+        .multi-note-banner strong { color: #6A4E12; }
     </style>
 </head>
 <body>
@@ -107,6 +118,8 @@
                 several values, so it is counted once per value.
             </p>
             <div class="dim-grid" id="dimGrid"></div>
+
+            <div class="multi-note-banner" id="multiNote"></div>
 
             <div class="pivot-actions">
                 <button class="csv-download-btn" id="downloadBtn" disabled>Download CSV</button>
@@ -199,15 +212,50 @@
             });
         }
 
+        function isMulti(key) {
+            const dim = DIMENSIONS.find(function (d) { return d.key === key; });
+            return !!(dim && dim.multi);
+        }
+
+        function selectedMultiDims() {
+            return selectedDims.filter(isMulti);
+        }
+
         function onDimToggle(key, checked) {
             if (checked) {
+                // Only one multi-value field at a time — two would produce a
+                // meaningless cross of the two lists (and the API rejects it).
+                if (isMulti(key) && selectedMultiDims().length > 0) {
+                    const cb = document.querySelector('.dim-option[data-key="' + key + '"] input');
+                    if (cb) cb.checked = false;
+                    showToast('Pick only one of Occupational series / Location at a time.', true);
+                    return;
+                }
                 if (selectedDims.indexOf(key) === -1) selectedDims.push(key);
             } else {
                 selectedDims = selectedDims.filter(function (k) { return k !== key; });
             }
             updateOrderBadges();
+            updateMultiNote();
             writeDimsToUrl();
             runPivot();
+        }
+
+        function updateMultiNote() {
+            const note = document.getElementById('multiNote');
+            const multi = selectedMultiDims().map(function (k) {
+                return DIMENSIONS.find(function (d) { return d.key === k; }).label;
+            });
+            if (multi.length === 0) {
+                note.style.display = 'none';
+                note.innerHTML = '';
+                return;
+            }
+            note.style.display = 'block';
+            note.innerHTML = '<strong>' + escapeHtml(multi.join(' / ')) +
+                ':</strong> a listing can have several, so it is counted once in ' +
+                'each value it has. These counts will not sum to the total number ' +
+                'of listings.';
         }
 
         // The shared filter manager owns the filter params in the URL (it rewrites
@@ -228,12 +276,22 @@
             const raw = new URLSearchParams(window.location.search).get('dims') || '';
             const keys = raw.split(',').map(function (k) { return k.trim(); }).filter(Boolean);
             const valid = DIMENSIONS.map(function (d) { return d.key; });
-            selectedDims = keys.filter(function (k) { return valid.indexOf(k) !== -1; });
+            // Keep only valid keys, and at most one multi-value field.
+            let seenMulti = false;
+            selectedDims = keys.filter(function (k) {
+                if (valid.indexOf(k) === -1) return false;
+                if (isMulti(k)) {
+                    if (seenMulti) return false;
+                    seenMulti = true;
+                }
+                return true;
+            });
             selectedDims.forEach(function (k) {
                 const cb = document.querySelector('.dim-option[data-key="' + k + '"] input');
                 if (cb) cb.checked = true;
             });
             updateOrderBadges();
+            updateMultiNote();
         }
 
         function updateOrderBadges() {

--- a/web/tests/test_api.py
+++ b/web/tests/test_api.py
@@ -1,4 +1,5 @@
 """Tests for USAJobs web API endpoints."""
+import csv
 import http.server
 import io
 import json
@@ -663,24 +664,58 @@ class TestPivot:
         assert body["headers"] == ["Department", "Year", "Count"]
         assert all(len(r) == 3 for r in body["rows"])
 
+    @staticmethod
+    def _csv_rows(path):
+        """Invoke the CSV endpoint and return (header, list-of-rows-with-int-count)."""
+        status, raw = _invoke_csv(pivot_mod.handler, path)
+        assert status == 200, path
+        reader = list(csv.reader(io.StringIO(raw.decode("utf-8"))))
+        header, body = reader[0], reader[1:]
+        rows = [r[:-1] + [int(r[-1])] for r in body]
+        return header, rows
+
     def test_count_equals_distinct_listings_for_single_value_dim(self):
-        """With no multi-value dim, the pivot total must equal the row count
-        of the filtered set (data is deduped to one row per control number)."""
-        _, pivot_body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=status")
-        pivot_total = sum(r[-1] for r in pivot_body["rows"])
-        # /api/jobs reports the filtered total via recordsFiltered
+        """With no multi-value dim, the FULL pivot total must equal the total
+        listing count (data is deduped to one row per control number)."""
+        _, rows = self._csv_rows("/api/pivot?dims=status&format=csv")
+        pivot_total = sum(r[-1] for r in rows)
         _, jobs_body = _invoke_handler(jobs_mod.handler, "/api/jobs?length=1")
         assert pivot_total == jobs_body["recordsTotal"]
 
-    def test_multi_value_dim_counts_each(self):
-        """A multi-value dim (series) should count a listing once per series,
-        so its total is >= the distinct listing count."""
-        _, series_body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=series")
-        series_total = sum(r[-1] for r in series_body["rows"])
+    def test_series_counts_each_distinct_listing(self):
+        """Series is multi-value: a listing is counted once per series it has,
+        so the full total exceeds the distinct listing count, and every per-group
+        count stays at or below the total (it is a DISTINCT-listing count)."""
+        _, rows = self._csv_rows("/api/pivot?dims=series&format=csv")
         _, jobs_body = _invoke_handler(jobs_mod.handler, "/api/jobs?length=1")
-        assert series_total >= jobs_body["recordsTotal"]
-        # no empty series labels leak through
-        assert all(r[0].strip() != "" for r in series_body["rows"])
+        total = jobs_body["recordsTotal"]
+        assert sum(r[-1] for r in rows) >= total
+        assert all(0 < r[-1] <= total for r in rows)
+        assert all(r[0].strip() != "" for r in rows)  # no empty labels
+
+    def test_location_counts_each_no_crash(self):
+        """Location is the heavy multi-value field (some listings carry 1000+
+        locations). It must complete, count in each location, and never exceed
+        the total listing count per group."""
+        header, rows = self._csv_rows("/api/pivot?dims=location&format=csv")
+        assert header == ["Location", "Count"]
+        _, jobs_body = _invoke_handler(jobs_mod.handler, "/api/jobs?length=1")
+        total = jobs_body["recordsTotal"]
+        assert sum(r[-1] for r in rows) >= total
+        assert all(0 < r[-1] <= total for r in rows)
+        assert all(r[0].strip() != "" for r in rows)
+
+    def test_two_multi_value_dims_is_400(self):
+        """Series + location together is rejected (would zip the two lists)."""
+        status, body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=series,location")
+        assert status == 400
+        assert "multi-value" in body["error"]
+
+    def test_response_flags_multi_value_dims(self):
+        _, single = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=department")
+        assert single["multi_value_dims"] == []
+        _, multi = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=location")
+        assert multi["multi_value_dims"] == ["location"]
 
     def test_filters_apply(self):
         status, body = _invoke_handler(


### PR DESCRIPTION
## Problem

The **location** pivot crashed in production (`FUNCTION_INVOCATION_FAILED`), and multi-value counting (series/location) used a slow correlated `LATERAL` join. Some postings list **1,000+ locations**, so the correlated unnest timed out.

## Fix

- **Flat projection-unnest + `COUNT(DISTINCT usajobsControlNumber)`** (same pattern as the working series chart in `aggregate.py`). A listing is counted **once in every value it actually has** — a posting open in DC and Atlanta counts under both. Location pivot now runs in **~0.7s** instead of timing out.
- The Count is the **true distinct-listing count** per group. Multi-value totals intentionally exceed the listing total — the UI now flags this.
- **Single-value pivots** keep `COUNT(*)` (exact, since data is one row per listing) — verified: department sum = 2,932,285 = total.
- **Reject two multi-value fields together** (would positionally zip the two lists) → 400, with a client-side guard too.

## UI

- Warning banner when a multi-value field is selected: *"Location: a listing can have several, so it is counted once in each value it has. These counts will not sum to the total number of listings."*
- Only one multi-value field selectable at a time (toast if you try a second).
- Both restore from shared URLs.

## Tests

Reworked to sum the **full CSV** (not just the 500-row preview): single-value sum == total, series/location count-each bounded by total, location no-crash, two-multi → 400, and the `multi_value_dims` response flag. **58 passed.**

Already deployed and verified on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)