### PR TITLE
Harden web API: atomic R2 cache, streaming CSV, safer errors

### DIFF
--- a/web/api/aggregate.py
+++ b/web/api/aggregate.py
@@ -193,9 +193,11 @@ class handler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(json.dumps(response).encode('utf-8'))
 
-        except Exception as e:
+        except Exception:
+            import traceback
+            traceback.print_exc()
             self.send_response(500)
             self.send_header('Content-Type', 'application/json')
             self.send_header('Access-Control-Allow-Origin', '*')
             self.end_headers()
-            self.wfile.write(json.dumps({'error': str(e)}).encode('utf-8'))
+            self.wfile.write(json.dumps({'error': 'internal server error'}).encode('utf-8'))

--- a/web/api/data_loader.py
+++ b/web/api/data_loader.py
@@ -30,8 +30,17 @@ def get_parquet_path():
         if age < _MAX_AGE_SECONDS:
             return _TMP_PATH
 
-    # Download from R2
+    # Download from R2.
+    #
+    # Fluid Compute serves concurrent requests from a single instance, so we
+    # must never write the cached file in place: boto3's download_file streams
+    # to its destination and is not atomic, so another in-flight request could
+    # read a half-written parquet (a DuckDB error, or silently wrong counts).
+    # Download to a unique temp file, then os.replace() it into the cache path
+    # — replace is atomic on the same filesystem, so readers always see either
+    # the old complete file or the new complete file, never a partial one.
     import boto3
+    import tempfile
 
     s3 = boto3.client(
         's3',
@@ -39,7 +48,16 @@ def get_parquet_path():
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
     )
-    s3.download_file(bucket_name, 'web/jobs_5yr.parquet', _TMP_PATH)
+
+    fd, tmp_download = tempfile.mkstemp(dir='/tmp', prefix='jobs_', suffix='.parquet')
+    os.close(fd)
+    try:
+        s3.download_file(bucket_name, 'web/jobs_5yr.parquet', tmp_download)
+        os.replace(tmp_download, _TMP_PATH)
+    except BaseException:
+        if os.path.exists(tmp_download):
+            os.remove(tmp_download)
+        raise
 
     return _TMP_PATH
 

--- a/web/api/download.py
+++ b/web/api/download.py
@@ -41,29 +41,42 @@ class handler(BaseHTTPRequestHandler):
                 f"ORDER BY COALESCE(CAST(\"openDate\" AS VARCHAR), '') DESC "
                 f"LIMIT {MAX_ROWS}"
             )
-            rows = conn.execute(query, bind_values).fetchall()
-            conn.close()
-
-            # Write CSV to buffer
-            buf = io.StringIO()
-            writer = csv.writer(buf)
-            writer.writerow(COLUMN_HEADERS)
-            writer.writerows(rows)
-
-            csv_bytes = buf.getvalue().encode('utf-8')
+            # Execute before sending headers so a query error still becomes a
+            # 500 (we can't change the status once the body starts streaming).
+            cursor = conn.execute(query, bind_values)
 
             self.send_response(200)
             self.send_header('Content-Type', 'text/csv; charset=utf-8')
             self.send_header('Content-Disposition', 'attachment; filename="usajobs_export.csv"')
             self.send_header('Access-Control-Allow-Origin', '*')
-            self.send_header('Content-Length', str(len(csv_bytes)))
             self.end_headers()
-            self.wfile.write(csv_bytes)
 
-        except Exception as e:
+            # Stream the CSV in batches so we never hold the full result (up to
+            # MAX_ROWS x ~14 cols) plus its encoded copy in memory at once.
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+
+            def flush():
+                self.wfile.write(buf.getvalue().encode('utf-8'))
+                buf.seek(0)
+                buf.truncate(0)
+
+            writer.writerow(COLUMN_HEADERS)
+            flush()
+            while True:
+                batch = cursor.fetchmany(10000)
+                if not batch:
+                    break
+                writer.writerows(batch)
+                flush()
+            conn.close()
+
+        except Exception:
             import json
+            import traceback
+            traceback.print_exc()
             self.send_response(500)
             self.send_header('Content-Type', 'application/json')
             self.send_header('Access-Control-Allow-Origin', '*')
             self.end_headers()
-            self.wfile.write(json.dumps({'error': str(e)}).encode('utf-8'))
+            self.wfile.write(json.dumps({'error': 'internal server error'}).encode('utf-8'))

--- a/web/api/filter_options.py
+++ b/web/api/filter_options.py
@@ -92,9 +92,11 @@ class handler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(json.dumps(response).encode('utf-8'))
 
-        except Exception as e:
+        except Exception:
+            import traceback
+            traceback.print_exc()
             self.send_response(500)
             self.send_header('Content-Type', 'application/json')
             self.send_header('Access-Control-Allow-Origin', '*')
             self.end_headers()
-            self.wfile.write(json.dumps({'error': str(e)}).encode('utf-8'))
+            self.wfile.write(json.dumps({'error': 'internal server error'}).encode('utf-8'))

--- a/web/api/jobs.py
+++ b/web/api/jobs.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 
@@ -23,9 +24,19 @@ class handler(BaseHTTPRequestHandler):
             parsed = urlparse(self.path)
             params = parse_qs(parsed.query)
 
-            draw = int(params.get('draw', ['1'])[0])
-            start = max(0, int(params.get('start', ['0'])[0]))
-            length = min(100, max(1, int(params.get('length', ['25'])[0])))
+            try:
+                draw = int(params.get('draw', ['1'])[0])
+                start = max(0, int(params.get('start', ['0'])[0]))
+                length = min(100, max(1, int(params.get('length', ['25'])[0])))
+            except (ValueError, TypeError):
+                self.send_response(400)
+                self.send_header('Content-Type', 'application/json')
+                self.send_header('Access-Control-Allow-Origin', '*')
+                self.end_headers()
+                self.wfile.write(json.dumps(
+                    {'error': 'draw, start, and length must be integers'}
+                ).encode('utf-8'))
+                return
 
             # Sort — support up to 3 sort columns
             order_parts = []
@@ -34,7 +45,10 @@ class handler(BaseHTTPRequestHandler):
                 dir_key = f'order[{i}][dir]'
                 if col_key not in params:
                     break
-                col_idx = int(params[col_key][0])
+                try:
+                    col_idx = int(params[col_key][0])
+                except (ValueError, TypeError):
+                    break
                 dir_raw = params.get(dir_key, ['desc'])[0].lower()
                 direction = 'ASC' if dir_raw != 'desc' else 'DESC'
                 col_name = SORTABLE_COLUMNS.get(col_idx)
@@ -110,12 +124,16 @@ class handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')
             self.send_header('Access-Control-Allow-Origin', '*')
+            self.send_header('Cache-Control', 'public, max-age=60')
             self.end_headers()
             self.wfile.write(json.dumps(response).encode('utf-8'))
 
-        except Exception as e:
+        except Exception:
+            # Log the real error to the server logs; don't leak internals
+            # (SQL text, file paths) to the client.
+            traceback.print_exc()
             self.send_response(500)
             self.send_header('Content-Type', 'application/json')
             self.send_header('Access-Control-Allow-Origin', '*')
             self.end_headers()
-            self.wfile.write(json.dumps({'error': str(e)}).encode('utf-8'))
+            self.wfile.write(json.dumps({'error': 'internal server error'}).encode('utf-8'))

--- a/web/api/pivot.py
+++ b/web/api/pivot.py
@@ -178,24 +178,39 @@ class handler(BaseHTTPRequestHandler):
             sql += f' LIMIT {limit}'
 
             conn = get_conn()
-            rows = conn.execute(sql, bind_values).fetchall()
-            conn.close()
 
             if want_csv:
-                buf = io.StringIO()
-                writer = csv.writer(buf)
-                writer.writerow(headers + ['Count'])
-                writer.writerows(rows)
-                csv_bytes = buf.getvalue().encode('utf-8')
+                # Execute before sending headers so a query error still becomes
+                # a 500, then stream in batches to bound memory.
+                cursor = conn.execute(sql, bind_values)
 
                 self.send_response(200)
                 self.send_header('Content-Type', 'text/csv; charset=utf-8')
                 self.send_header('Content-Disposition', 'attachment; filename="usajobs_pivot.csv"')
                 self.send_header('Access-Control-Allow-Origin', '*')
-                self.send_header('Content-Length', str(len(csv_bytes)))
                 self.end_headers()
-                self.wfile.write(csv_bytes)
+
+                buf = io.StringIO()
+                writer = csv.writer(buf)
+
+                def flush():
+                    self.wfile.write(buf.getvalue().encode('utf-8'))
+                    buf.seek(0)
+                    buf.truncate(0)
+
+                writer.writerow(headers + ['Count'])
+                flush()
+                while True:
+                    batch = cursor.fetchmany(10000)
+                    if not batch:
+                        break
+                    writer.writerows(batch)
+                    flush()
+                conn.close()
                 return
+
+            rows = conn.execute(sql, bind_values).fetchall()
+            conn.close()
 
             truncated = len(rows) > MAX_PREVIEW_ROWS
             if truncated:
@@ -209,5 +224,7 @@ class handler(BaseHTTPRequestHandler):
                 'multi_value_dims': multi,
             })
 
-        except Exception as e:
-            self._send_json(500, {'error': str(e)})
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            self._send_json(500, {'error': 'internal server error'})

--- a/web/tests/test_api.py
+++ b/web/tests/test_api.py
@@ -748,3 +748,35 @@ class TestPivot:
         lines = text.splitlines()
         assert lines[0] == "Department,Count"
         assert len(lines) > 1
+
+
+# ===================================================================
+# Hardening: download streaming, bad-input validation
+# ===================================================================
+
+from api import download as download_mod
+
+
+class TestHardening:
+    def test_download_csv_streams_header_and_rows(self):
+        status, raw = _invoke_csv(download_mod.handler, "/api/download?length=5")
+        assert status == 200
+        lines = raw.decode("utf-8").splitlines()
+        assert lines[0] == ",".join(col_mod.COLUMN_HEADERS)
+        assert len(lines) > 1
+
+    def test_download_respects_filters(self):
+        status, raw = _invoke_csv(
+            download_mod.handler,
+            "/api/download?filter_hiringAgencyName=Department%20of%20the%20Treasury",
+        )
+        assert status == 200
+        reader = list(csv.reader(io.StringIO(raw.decode("utf-8"))))
+        ag_idx = col_mod.COLUMNS.index("hiringAgencyName")
+        # every data row is Treasury
+        assert all(r[ag_idx] == "Department of the Treasury" for r in reader[1:])
+
+    def test_jobs_bad_length_is_400(self):
+        status, body = _invoke_handler(jobs_mod.handler, "/api/jobs?length=abc")
+        assert status == 400
+        assert "integer" in body["error"]


### PR DESCRIPTION
Follow-up review fixes for latent issues found while building the pivot feature (same failure class as the location crash — works under light load, breaks under concurrency/scale).

## Fixes

1. **Atomic R2 cache** (`data_loader.py`) — download to a unique temp file, then `os.replace()` into the cache path. Fluid Compute serves concurrent requests from one instance and `boto3.download_file` writes in place (not atomic), so a second request could read a half-written parquet → DuckDB error or silently wrong counts.

2. **Streaming CSV** (`download.py`, `pivot.py`) — stream in 10k-row batches via `fetchmany` instead of materializing the whole result + its encoded copy in memory. The full export can be 500k × 14 cols; the old path risked a function OOM.

3. **No internal error leakage** (all endpoints) — log the real exception to stderr (server logs) and return a generic `"internal server error"` instead of echoing `str(e)` (SQL text / file paths) to clients.

4. **Validation** (`jobs.py`) — `draw`/`start`/`length` non-integers now return **400**, not a swallowed 500; a non-integer sort column is ignored rather than erroring.

5. **Caching** (`jobs.py`) — added `Cache-Control` (was the only endpoint without one).

## Not changed (deliberately)
No SQL injection surface: every endpoint whitelists column/field/dimension names and uses DuckDB bind params for values.

## Tests
Added streaming-download (header + rows + filter-respect) and jobs bad-input 400. **61 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)