### PR TITLE
Graceful handling of oversized CSV exports

### DIFF
--- a/web/api/download.py
+++ b/web/api/download.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import json
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 
@@ -10,7 +11,11 @@ sys.path.insert(0, os.path.dirname(__file__))
 from data_loader import get_parquet_path, get_conn
 from columns import COLUMNS, COLUMN_HEADERS, parse_filters
 
-MAX_ROWS = 500000
+# Max rows we will export in one CSV. A full unfiltered export is ~2.9M rows /
+# ~140 MB, which exceeds the serverless response limits; streamed exports in the
+# tens-of-MB range work fine. Above this we return a clear 413 so the UI can ask
+# the user to add filters instead of failing opaquely.
+MAX_ROWS = 150000
 
 
 class handler(BaseHTTPRequestHandler):
@@ -21,6 +26,15 @@ class handler(BaseHTTPRequestHandler):
         self.send_header('Access-Control-Allow-Headers', 'Content-Type')
         self.end_headers()
 
+    def _send_json(self, status, obj):
+        body = json.dumps(obj).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     def do_GET(self):
         try:
             parsed = urlparse(self.path)
@@ -30,19 +44,35 @@ class handler(BaseHTTPRequestHandler):
             filter_clauses, bind_values = parse_filters(params)
             where_sql = f'WHERE {" AND ".join(filter_clauses)}' if filter_clauses else ''
 
-            col_list = ', '.join([f'COALESCE(CAST("{c}" AS VARCHAR), \'\')' for c in COLUMNS])
-
             conn = get_conn()
             parquet_path = get_parquet_path()
 
+            # Guard oversized exports up front so the client gets an actionable
+            # message rather than an opaque function failure.
+            row_count = conn.execute(
+                f"SELECT COUNT(*) FROM read_parquet('{parquet_path}') {where_sql}",
+                bind_values,
+            ).fetchone()[0]
+            if row_count > MAX_ROWS:
+                conn.close()
+                self._send_json(413, {
+                    'error': 'too_many_rows',
+                    'rows': row_count,
+                    'limit': MAX_ROWS,
+                    'message': (
+                        f'This export has {row_count:,} rows, which is too large to '
+                        f'download here. Add filters to narrow it to {MAX_ROWS:,} rows or fewer.'
+                    ),
+                })
+                return
+
+            col_list = ', '.join([f'COALESCE(CAST("{c}" AS VARCHAR), \'\')' for c in COLUMNS])
             query = (
                 f"SELECT {col_list} FROM read_parquet('{parquet_path}') "
                 f"{where_sql} "
                 f"ORDER BY COALESCE(CAST(\"openDate\" AS VARCHAR), '') DESC "
                 f"LIMIT {MAX_ROWS}"
             )
-            # Execute before sending headers so a query error still becomes a
-            # 500 (we can't change the status once the body starts streaming).
             cursor = conn.execute(query, bind_values)
 
             self.send_response(200)
@@ -51,8 +81,8 @@ class handler(BaseHTTPRequestHandler):
             self.send_header('Access-Control-Allow-Origin', '*')
             self.end_headers()
 
-            # Stream the CSV in batches so we never hold the full result (up to
-            # MAX_ROWS x ~14 cols) plus its encoded copy in memory at once.
+            # Stream the CSV in batches (Vercel Fluid Compute streams the body),
+            # so we never hold the whole result + its encoded copy in memory.
             buf = io.StringIO()
             writer = csv.writer(buf)
 
@@ -72,11 +102,6 @@ class handler(BaseHTTPRequestHandler):
             conn.close()
 
         except Exception:
-            import json
             import traceback
             traceback.print_exc()
-            self.send_response(500)
-            self.send_header('Content-Type', 'application/json')
-            self.send_header('Access-Control-Allow-Origin', '*')
-            self.end_headers()
-            self.wfile.write(json.dumps({'error': 'internal server error'}).encode('utf-8'))
+            self._send_json(500, {'error': 'internal server error'})

--- a/web/api/pivot.py
+++ b/web/api/pivot.py
@@ -180,8 +180,6 @@ class handler(BaseHTTPRequestHandler):
             conn = get_conn()
 
             if want_csv:
-                # Execute before sending headers so a query error still becomes
-                # a 500, then stream in batches to bound memory.
                 cursor = conn.execute(sql, bind_values)
 
                 self.send_response(200)
@@ -190,6 +188,7 @@ class handler(BaseHTTPRequestHandler):
                 self.send_header('Access-Control-Allow-Origin', '*')
                 self.end_headers()
 
+                # Stream in batches (Vercel Fluid Compute streams the body).
                 buf = io.StringIO()
                 writer = csv.writer(buf)
 

--- a/web/index.html
+++ b/web/index.html
@@ -138,6 +138,10 @@
         const API_BASE = '';
         window.API_BASE = API_BASE;
 
+        // Keep in sync with MAX_ROWS in api/download.py. Larger exports exceed
+        // the serverless response limits, so we ask the user to filter first.
+        const DOWNLOAD_ROW_LIMIT = 150000;
+
         // ============================================
         // Column Configuration
         // ============================================
@@ -514,6 +518,19 @@
             csvBtn.textContent = 'Download CSV';
             csvBtn.title = 'Download filtered data as CSV';
             csvBtn.addEventListener('click', function () {
+                // The page already knows the filtered row count — check it
+                // before downloading so an oversized export shows a friendly
+                // message instead of an opaque error page.
+                const info = table.page.info();
+                const count = info ? info.recordsDisplay : null;
+                if (count !== null && count > DOWNLOAD_ROW_LIMIT) {
+                    showToast(
+                        'Too many rows to download (' + formatNumber(count) + '). ' +
+                        'Add filters to narrow to ' + formatNumber(DOWNLOAD_ROW_LIMIT) + ' or fewer.',
+                        true
+                    );
+                    return;
+                }
                 const qs = filterManager.getFilterQueryString();
                 const url = API_BASE + '/api/download' + (qs ? '?' + qs : '');
                 window.open(url, '_blank');

--- a/web/tests/test_api.py
+++ b/web/tests/test_api.py
@@ -758,8 +758,11 @@ from api import download as download_mod
 
 
 class TestHardening:
+    # A single month stays well under the download row limit.
+    _BOUNDED = "filter_openDate_min=2024-06-01&filter_openDate_max=2024-06-30"
+
     def test_download_csv_streams_header_and_rows(self):
-        status, raw = _invoke_csv(download_mod.handler, "/api/download?length=5")
+        status, raw = _invoke_csv(download_mod.handler, f"/api/download?{self._BOUNDED}")
         assert status == 200
         lines = raw.decode("utf-8").splitlines()
         assert lines[0] == ",".join(col_mod.COLUMN_HEADERS)
@@ -768,13 +771,22 @@ class TestHardening:
     def test_download_respects_filters(self):
         status, raw = _invoke_csv(
             download_mod.handler,
-            "/api/download?filter_hiringAgencyName=Department%20of%20the%20Treasury",
+            "/api/download?filter_hiringAgencyName=Department%20of%20the%20Treasury"
+            "&filter_openDate_min=2024-01-01&filter_openDate_max=2024-12-31",
         )
         assert status == 200
         reader = list(csv.reader(io.StringIO(raw.decode("utf-8"))))
         ag_idx = col_mod.COLUMNS.index("hiringAgencyName")
         # every data row is Treasury
         assert all(r[ag_idx] == "Department of the Treasury" for r in reader[1:])
+
+    def test_download_oversized_returns_413(self):
+        """An unfiltered export exceeds the row limit -> graceful 413, not a crash."""
+        status, body = _invoke_handler(download_mod.handler, "/api/download")
+        assert status == 413
+        assert body["error"] == "too_many_rows"
+        assert body["rows"] > body["limit"]
+        assert "Add filters" in body["message"]
 
     def test_jobs_bad_length_is_400(self):
         status, body = _invoke_handler(jobs_mod.handler, "/api/jobs?length=abc")


### PR DESCRIPTION
## Problem

A full unfiltered CSV export (~2.9M rows / ~140 MB) exceeds the serverless response limits and failed with an opaque **"A server error has occurred"**. Streamed exports in the tens-of-MB range work fine — verified **44 MB / 168k rows** on production — so only very large exports are the issue.

## Fix

- **`download.py`** — pre-count the filtered rows; if above `MAX_ROWS` (150k), return a clear **413** (`too_many_rows` + a human-readable `message`) instead of crashing. Stream the CSV in batches otherwise (Vercel Fluid Compute streams the body).
- **`index.html`** (the main site, per request) — the Download CSV button checks the filtered row count it already has from the table and shows a friendly toast (*"Too many rows to download (2.9M). Add filters to narrow to 150,000 or fewer."*) instead of opening a tab to an error response. Verified in-browser.
- **`pivot.py`** — comment-only; CSV path stays streaming.

## Tests
Bounded streaming download, filter-respect, and oversized → 413. **62 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)