### PR TITLE
Pivot: intuitive ordering + download underlying job list

### DIFF
--- a/web/api/pivot.py
+++ b/web/api/pivot.py
@@ -65,6 +65,21 @@ MAX_PREVIEW_ROWS = 500  # rows returned to the on-page preview
 MAX_CSV_ROWS = 200000   # safety cap on a CSV download
 
 
+def _order_clause(group_cols):
+    """Intuitive ordering for a long-format pivot.
+
+    Group by the leading dimension columns ascending (so all rows for one value
+    of the first column stay together), then rank by count within the innermost
+    level. With a single dimension this is just count-descending (top first):
+
+      [Department]        -> ORDER BY cnt DESC, d0
+      [Year, Department]  -> ORDER BY d0, cnt DESC, d1   (each year, top depts)
+    """
+    leading = group_cols[:-1]
+    parts = list(leading) + ['cnt DESC', group_cols[-1]]
+    return ', '.join(parts)
+
+
 def _build_query(dims, where_sql):
     """Build the pivot SQL for the given ordered dimension keys.
 
@@ -74,6 +89,7 @@ def _build_query(dims, where_sql):
     parquet_path = get_parquet_path()
     headers = [DIMENSIONS[k][0] for k in dims]
     group_cols = [f'd{i}' for i in range(len(dims))]
+    order_by = _order_clause(group_cols)
 
     multi_idx = next((i for i, k in enumerate(dims) if DIMENSIONS[k][2]), None)
 
@@ -86,7 +102,7 @@ def _build_query(dims, where_sql):
             f"FROM read_parquet('{parquet_path}') "
             f"{where_sql} "
             f"GROUP BY {', '.join(group_cols)} "
-            f"ORDER BY cnt DESC, {', '.join(group_cols)}"
+            f"ORDER BY {order_by}"
         )
         return sql, headers
 
@@ -114,7 +130,7 @@ def _build_query(dims, where_sql):
         f"FROM ({inner}) sub "
         f"WHERE {multi_alias} IS NOT NULL AND {multi_alias} <> '' "
         f"GROUP BY {', '.join(group_cols)} "
-        f"ORDER BY cnt DESC, {', '.join(group_cols)}"
+        f"ORDER BY {order_by}"
     )
     return sql, headers
 

--- a/web/pivot.html
+++ b/web/pivot.html
@@ -89,6 +89,8 @@
             font-size: 0.9rem;
         }
         .multi-note-banner strong { color: #6A4E12; }
+        .joblist-note { margin-top: 0.5rem; font-size: 0.88rem; color: #7A6E62; }
+        .joblist-note a { color: #2d6e4e; }
     </style>
 </head>
 <body>
@@ -122,9 +124,11 @@
             <div class="multi-note-banner" id="multiNote"></div>
 
             <div class="pivot-actions">
-                <button class="csv-download-btn" id="downloadBtn" disabled>Download CSV</button>
+                <button class="csv-download-btn" id="downloadBtn" disabled>Download counts (CSV)</button>
+                <button class="csv-download-btn" id="jobListBtn" disabled>Download job list (CSV)</button>
                 <span class="pivot-result-meta" id="resultMeta"></span>
             </div>
+            <div class="joblist-note" id="jobListNote"></div>
         </div>
 
         <div class="pivot-table-wrapper">
@@ -142,6 +146,10 @@
     <script>
         const API_BASE = '';
         window.API_BASE = API_BASE;
+
+        // Keep in sync with MAX_ROWS in api/download.py.
+        const DOWNLOAD_ROW_LIMIT = 150000;
+        const FULL_DATASET_URL = 'https://pub-317c58882ec04f329b63842c1eb65b0c.r2.dev/web/jobs_5yr.parquet';
 
         // Dimensions the pivot endpoint accepts. `multi` flags '; '-delimited
         // fields where one listing can carry several values.
@@ -381,7 +389,7 @@
             result.innerHTML = html;
 
             if (data.truncated) {
-                meta.textContent = 'Showing the top ' + formatNumber(data.preview_limit) +
+                meta.textContent = 'Showing the first ' + formatNumber(data.preview_limit) +
                     ' rows. Download the CSV for the full table.';
             } else {
                 meta.textContent = formatNumber(data.rows.length) + ' rows.';
@@ -391,6 +399,50 @@
         function downloadCsv() {
             if (selectedDims.length === 0) return;
             window.location.href = API_BASE + '/api/pivot?format=csv&' + currentQueryString();
+        }
+
+        function downloadJobList() {
+            const filterQs = filterManager ? filterManager.getFilterQueryString() : '';
+            window.open(API_BASE + '/api/download' + (filterQs ? '?' + filterQs : ''), '_blank');
+        }
+
+        // The job list is the underlying rows for the current filters (not the
+        // pivot dimensions). Only offer it when the filtered set is small enough
+        // to export; otherwise point to the full dataset.
+        let jobListReqId = 0;
+        async function updateJobListButton() {
+            const btn = document.getElementById('jobListBtn');
+            const note = document.getElementById('jobListNote');
+            const filterQs = filterManager ? filterManager.getFilterQueryString() : '';
+
+            btn.disabled = true;
+            note.textContent = 'Checking…';
+
+            const myReq = ++jobListReqId;
+            let count;
+            try {
+                const url = API_BASE + '/api/jobs?length=1' + (filterQs ? '&' + filterQs : '');
+                const data = await (await fetch(url)).json();
+                count = data.recordsFiltered;
+            } catch (e) {
+                count = null;
+            }
+            if (myReq !== jobListReqId) return;  // a newer filter change superseded this
+
+            if (count == null) {
+                note.textContent = '';
+            } else if (count === 0) {
+                note.textContent = 'No jobs match the current filters.';
+            } else if (count > DOWNLOAD_ROW_LIMIT) {
+                note.innerHTML = 'Full job list available once filtered under ' +
+                    formatNumber(DOWNLOAD_ROW_LIMIT) + ' jobs (currently ' + formatNumber(count) +
+                    '). Or get the <a href="' + FULL_DATASET_URL + '" target="_blank" rel="noopener">' +
+                    'full dataset (parquet)</a>.';
+            } else {
+                btn.disabled = false;
+                btn.textContent = 'Download job list (' + formatNumber(count) + ' jobs, CSV)';
+                note.textContent = '';
+            }
         }
 
         document.addEventListener('DOMContentLoaded', function () {
@@ -405,17 +457,20 @@
                 onFilterChange: function () {
                     writeDimsToUrl();
                     runPivot();
+                    updateJobListButton();
                 }
             });
             // No DataTable on this page — init(null) just wires up the filter bar.
             filterManager.init(null);
 
             document.getElementById('downloadBtn').addEventListener('click', downloadCsv);
+            document.getElementById('jobListBtn').addEventListener('click', downloadJobList);
 
             // Restore group-by + filters from the URL so a shared link reproduces
             // the whole pivot. (The manager already restored filters in its ctor.)
             restoreDimsFromUrl();
             if (selectedDims.length > 0) runPivot();
+            updateJobListButton();
         });
     </script>
 </body>

--- a/web/tests/test_api.py
+++ b/web/tests/test_api.py
@@ -664,6 +664,18 @@ class TestPivot:
         assert body["headers"] == ["Department", "Year", "Count"]
         assert all(len(r) == 3 for r in body["rows"])
 
+    def test_multi_dim_ordering_groups_by_leading_column(self):
+        """Rows group by the leading column, ranked by count within it —
+        e.g. all of one year together, departments by count inside it."""
+        from itertools import groupby
+        _, body = _invoke_handler(pivot_mod.handler, "/api/pivot?dims=year,department")
+        rows = body["rows"]
+        years = [r[0] for r in rows]
+        assert years == sorted(years), "leading column should be grouped/ordered"
+        for _year, grp in groupby(rows, key=lambda r: r[0]):
+            counts = [r[-1] for r in grp]
+            assert counts == sorted(counts, reverse=True), "count desc within each group"
+
     @staticmethod
     def _csv_rows(path):
         """Invoke the CSV endpoint and return (header, list-of-rows-with-int-count)."""


### PR DESCRIPTION
Two pivot-page improvements.

## 1. Intuitive ordering
Multi-column pivots were sorted by a single global count-desc, which scattered the rows (e.g. 2018, 2019, 2022, 2023, 2018, 2023… for a Year/Department pivot). Now rows **group by the leading column(s) ascending and rank by count within** the innermost level:

- `dims=department` → count desc (top first) — unchanged
- `dims=year,department` → all of 2018 together, departments by count, then 2019, …

## 2. Download the underlying job list
When the current filters narrow the set under the export limit (150k), the pivot page offers a **"Download job list (N jobs, CSV)"** button that exports the underlying rows via `/api/download` with the same filters. When still too large, it points to the full dataset parquet instead. The existing button is relabeled **"Download counts (CSV)"** to distinguish the two.

Verified in-browser: disabled + "filter under 150,000 (currently 2.9M)" + full-dataset link when unfiltered; enabled as "Download job list (25,990 jobs, CSV)" with a one-month filter.

## Tests
Locks in the grouped ordering (leading column grouped, count desc within). **63 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)