### PR TITLE
Split historical repoll into its own workflow

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -28,6 +28,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Serialize with the repoll workflow: both mutate the parquet files in R2,
+# so they must never write concurrently. Queue rather than cancel.
+concurrency:
+  group: usajobs-r2-data-write
+  cancel-in-progress: false
+
 jobs:
   update-data:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -250,40 +256,10 @@ jobs:
             fs.unlinkSync(warningFile);
           }
 
-    - name: Re-poll status for non-final jobs
-      env:
-        GITHUB_ACTIONS: true
-      run: |
-        # Always poll recent data: current year + previous year
-        CURRENT_YEAR=$(date +'%Y')
-        PREV_YEAR=$((CURRENT_YEAR - 1))
-        YEARS="$PREV_YEAR $CURRENT_YEAR"
-
-        # Older years rotate by day of week (1=Mon .. 7=Sun)
-        # so each day only repolls a small batch:
-        #
-        # Mon: 2013-2016  (~257 dates, mostly resolved)
-        # Tue: 2017-2018  (~719 dates)
-        # Wed: 2019-2020  (~709 dates)
-        # Thu: 2021-2022  (~702 dates)
-        # Fri: 2023       (~352 dates)
-        # Sat/Sun: just current + previous year
-        #
-        DOW=$(date +%u)
-        case $DOW in
-          1) YEARS="2013 2014 2015 2016 $YEARS" ;;
-          2) YEARS="2017 2018 $YEARS" ;;
-          3) YEARS="2019 2020 $YEARS" ;;
-          4) YEARS="2021 2022 $YEARS" ;;
-          5) YEARS="2023 $YEARS" ;;
-        esac
-
-        # Remove duplicates
-        YEARS=$(echo $YEARS | tr ' ' '\n' | sort -u | tr '\n' ' ')
-
-        echo "Day of week: $DOW"
-        echo "Re-polling years: $YEARS"
-        python scripts/repoll_status.py --years $YEARS --skip-recent-days 14
+    # NOTE: Historical status re-polling (older than the last 14 days) now runs
+    # in its own workflow (.github/workflows/repoll-status.yml) so a slow/large
+    # repoll can never block today's data from publishing. The daily collection
+    # above already re-fetches the last 14 days with fresh statuses.
 
     - name: Run data integrity tests
       id: data_tests

--- a/.github/workflows/repoll-status.yml
+++ b/.github/workflows/repoll-status.yml
@@ -1,0 +1,200 @@
+name: Repoll Historical Status
+
+# Re-polls status transitions for jobs OLDER than the last 14 days (the daily
+# workflow already refreshes the recent window). Runs on its own so a slow or
+# large repoll can never block today's data from publishing.
+#
+# Rotation: one year-group per run, cycling by day-of-year. 2013-2018 (sparse)
+# share one slot; each year from 2019 through the current year gets its own —
+# a full sweep every ~9 days today, extending by one day each new year. A
+# wall-clock budget stops the run cleanly and opens an issue if it can't finish
+# its group in time.
+
+on:
+  schedule:
+    # 15:00 UTC — well after the daily update (07:00 UTC) has finished.
+    - cron: '0 15 * * *'
+  workflow_dispatch:
+    inputs:
+      years:
+        description: "Override years to repoll (space-separated, e.g. '2025 2026'). Blank = today's rotation."
+        type: string
+        default: ""
+      max_minutes:
+        description: "Wall-clock budget for the repoll step (minutes)."
+        type: string
+        default: "90"
+
+permissions:
+  contents: read
+  issues: write
+
+# Serialize with the daily update: both mutate the parquet files in R2, so they
+# must never write concurrently. Queue rather than cancel.
+concurrency:
+  group: usajobs-r2-data-write
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  repoll:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        lfs: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install boto3 pytest
+
+    - name: Download data from R2
+      env:
+        R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+      run: |
+        python3 -c "
+        import boto3, os
+        s3 = boto3.client('s3',
+            endpoint_url=os.environ['R2_ENDPOINT_URL'],
+            aws_access_key_id=os.environ['R2_ACCESS_KEY_ID'],
+            aws_secret_access_key=os.environ['R2_SECRET_ACCESS_KEY'],
+        )
+        os.makedirs('data', exist_ok=True)
+        paginator = s3.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket='usajobs-data', Prefix='data/'):
+            for obj in page.get('Contents', []):
+                key = obj['Key']
+                print(f'Downloading {key} ({obj[\"Size\"]/1024/1024:.1f} MB)')
+                s3.download_file('usajobs-data', key, key)
+        print('Done')
+        "
+        echo "Checking data files:"
+        ls -lh data/*.parquet | head -5
+
+    - name: Validate downloaded data from R2
+      run: |
+        python3 -c "
+        import os, sys, datetime
+        import pyarrow.parquet as pq
+
+        missing, empty = [], []
+        current_year = datetime.date.today().year
+        for year in range(2013, current_year + 1):
+            path = os.path.join('data', f'historical_jobs_{year}.parquet')
+            if not os.path.exists(path):
+                missing.append(path)
+            elif pq.read_metadata(path).num_rows == 0:
+                empty.append(f'{path} (0 rows)')
+
+        if missing: print('MISSING:', *missing, sep='\n  ')
+        if empty:   print('EMPTY:', *empty, sep='\n  ')
+        if missing or empty:
+            sys.exit(1)
+        print('R2 download validated: all historical files present and non-empty')
+        "
+
+    - name: Re-poll status for non-final jobs
+      env:
+        GITHUB_ACTIONS: true
+        REPOLL_YEARS: ${{ inputs.years }}
+        MAX_MINUTES: ${{ inputs.max_minutes || '90' }}
+      run: |
+        if [ -n "$REPOLL_YEARS" ]; then
+          YEARS="$REPOLL_YEARS"
+          echo "Manual override — repolling years: $YEARS"
+        else
+          # One year-group per run, rotating by day-of-year. 2013-2018 (sparse)
+          # share slot 0; every year from 2019 through the CURRENT year gets its
+          # own slot, so the rotation extends automatically each January.
+          YEARS=$(python3 -c "import datetime; cy=datetime.date.today().year; groups=[list(range(2013,2019))]+[[y] for y in range(2019,cy+1)]; doy=datetime.date.today().timetuple().tm_yday; print(' '.join(map(str, groups[doy % len(groups)])))")
+          echo "Rotation selected years: $YEARS"
+        fi
+
+        python scripts/repoll_status.py --years $YEARS --skip-recent-days 14 --max-minutes "$MAX_MINUTES"
+
+    - name: Run data integrity tests
+      id: data_tests
+      run: |
+        cd update
+        python test_data_integrity.py
+
+    - name: Prep web data
+      env:
+        USAJOBS_API_TOKEN: ${{ secrets.USAJOBS_API_TOKEN }}
+      run: |
+        python scripts/prep_web_data.py
+
+    - name: Run API tests against new web data
+      run: |
+        python -m pytest web/tests/test_api.py -v
+
+    - name: Sync to R2
+      if: steps.data_tests.outcome == 'success'
+      env:
+        R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+      run: |
+        python scripts/sync_to_r2.py
+
+    - name: Alert if repoll did not finish its year
+      if: always()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const markerFile = 'logs/REPOLL_INCOMPLETE.txt';
+          if (fs.existsSync(markerFile)) {
+            const content = fs.readFileSync(markerFile, 'utf8');
+            const today = new Date().toISOString().split('T')[0];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = '## Repoll Did Not Finish Its Assigned Year\n\n' +
+              'The historical status repoll hit its time budget before covering every date. ' +
+              'Partial progress was saved and synced; remaining dates will be retried on the next run. ' +
+              'If this recurs for the same year, the year may need splitting or the budget raising.\n\n' +
+              '**Details:**\n```\n' + content + '\n```\n\n' +
+              `[View the workflow run](${runUrl})`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Repoll Incomplete - ' + today,
+              body,
+              labels: ['data-issue', 'automated'],
+              assignees: ['abigailhaddad'],
+            });
+            fs.unlinkSync(markerFile);
+          }
+
+    - name: Alert on workflow failure
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const today = new Date().toISOString().split('T')[0];
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: 'Repoll Workflow Failed - ' + today,
+            body: 'The historical status repoll workflow failed (error, timeout, or failing test). ' +
+              'No data may have been synced for this run.\n\n' +
+              `[View the workflow run](${runUrl})`,
+            labels: ['bug', 'automated'],
+            assignees: ['abigailhaddad'],
+          });

--- a/scripts/repoll_status.py
+++ b/scripts/repoll_status.py
@@ -261,6 +261,9 @@ def main():
     parser.add_argument("--workers", type=int, default=15, help="Parallel API workers (default: 15)")
     parser.add_argument("--skip-recent-days", type=int, default=14,
                         help="Skip dates within this many days of today (default: 14, covered by daily collection)")
+    parser.add_argument("--max-minutes", type=float, default=None,
+                        help="Stop cleanly after this many minutes, saving partial progress and "
+                             "writing logs/REPOLL_INCOMPLETE.txt (default: no limit)")
     args = parser.parse_args()
 
     # Find all historical parquet files
@@ -342,8 +345,19 @@ def main():
     # Process in batches for parallel fetching
     batch_size = args.workers
     i = 0
+    stopped_early = False
 
     while i < total_dates:
+        # Honor a wall-clock budget so the workflow always leaves time to
+        # save, prep and sync. Partial progress is preserved (incremental
+        # saves already happened) and the final save below flushes the rest.
+        if args.max_minutes and (time.time() - start_time) > args.max_minutes * 60:
+            stopped_early = True
+            log(f"\n⏱️  Time budget of {args.max_minutes:.0f} min reached — "
+                f"stopping at {dates_queried}/{total_dates} dates. "
+                f"Remaining dates will be picked up on the next run.")
+            break
+
         batch = all_dates[i:i + batch_size]
 
         # Fetch batch in parallel
@@ -503,6 +517,25 @@ def main():
             for cn, old, new in all_transitions:
                 f.write(f'{cn},{old},{new}\n')
         log(f"  Detailed transitions: {summary_path}")
+
+    # Loud, non-fatal signal that this run did not cover all assigned dates.
+    # The workflow turns this marker into a GitHub issue, and the remaining
+    # dates get retried on the next scheduled run.
+    if stopped_early or dates_queried < total_dates:
+        marker_path = os.path.join(os.path.dirname(__file__), '..', 'logs',
+                                   'REPOLL_INCOMPLETE.txt')
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        reason = (f"Hit --max-minutes budget of {args.max_minutes:.0f} min"
+                  if stopped_early else "Loop ended before all dates were queried")
+        with open(marker_path, 'w') as f:
+            f.write(f"Repoll did not finish all assigned dates.\n"
+                    f"Reason: {reason}\n"
+                    f"Progress: {dates_queried}/{total_dates} dates queried "
+                    f"({total_dates - dates_queried} remaining)\n"
+                    f"Years this run: {sorted(files.keys())}\n"
+                    f"Partial progress WAS saved and synced. "
+                    f"Remaining dates will be retried on the next scheduled run.\n")
+        log(f"\n⚠️  Wrote {marker_path} (workflow will open an issue).")
 
     log(f"{'='*60}")
 


### PR DESCRIPTION
## Problem
The daily update kept hitting GitHub's hard 2h job limit during the historical status repoll, which runs **before** prep+sync. On timeout days nothing published, and since a timeout is a *cancellation* the `if: failure()` alert never fired — silent staleness (e.g. 2026-06-30 and 2026-07-02).

## Fix
- **daily-data-update.yml**: drop the big repoll step so the daily always publishes fast (it already re-collects the last 14 days with fresh statuses).
- **repoll-status.yml (new)**: dedicated workflow, one year-group per day. 2013–2018 (sparse) share slot 0; every year from 2019 through the current year gets its own slot, extending automatically each January. Full publish tail (integrity → prep → API tests → R2 sync) and loud GitHub-issue alerts on incomplete/failure.
- **repoll_status.py**: `--max-minutes` budget stops cleanly, saves partial progress, drops `logs/REPOLL_INCOMPLETE.txt` for the alert.
- Shared `concurrency` group so the two workflows never write R2 at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)