### PR TITLE
Alert when a fetch hits an exact pagination cap (500 / 10,000)

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -256,6 +256,42 @@ jobs:
             fs.unlinkSync(warningFile);
           }
 
+    - name: Check for pagination cap hits (500 / 10,000)
+      if: always()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const capFile = 'logs/CAP_HIT_WARNING.txt';
+
+          if (fs.existsSync(capFile)) {
+            const content = fs.readFileSync(capFile, 'utf8');
+            console.log('Warning: a collection hit an exact pagination cap!');
+
+            const today = new Date().toISOString().split('T')[0];
+            const runUrl = context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId;
+
+            const body = '## Pagination Cap Hit (exactly 500 or 10,000)\n\n' +
+              'A collection returned a count that lands *exactly* on a known page-size (500) ' +
+              'or max-results (10,000) boundary. That is the classic signature of pagination ' +
+              'silently stopping early — the numbers for the affected query may be truncated.\n\n' +
+              '**Affected fetches:**\n```\n' + content + '\n```\n\n' +
+              '**Action:** Confirm whether the real total actually equals that number (a rare ' +
+              'coincidence) or whether pagination broke and the data needs re-collecting.\n\n' +
+              '[View the workflow run](' + runUrl + ')';
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Pagination Cap Hit - ' + today,
+              body: body,
+              labels: ['bug', 'data-issue'],
+              assignees: ['abigailhaddad']
+            });
+
+            fs.unlinkSync(capFile);
+          }
+
     # NOTE: Historical status re-polling (older than the last 14 days) now runs
     # in its own workflow (.github/workflows/repoll-status.yml) so a slow/large
     # repoll can never block today's data from publishing. The daily collection

--- a/.github/workflows/repoll-status.yml
+++ b/.github/workflows/repoll-status.yml
@@ -153,6 +153,35 @@ jobs:
       run: |
         python scripts/sync_to_r2.py
 
+    - name: Check for pagination cap hits (500 / 10,000)
+      if: always()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const capFile = 'logs/CAP_HIT_WARNING.txt';
+          if (fs.existsSync(capFile)) {
+            const content = fs.readFileSync(capFile, 'utf8');
+            const today = new Date().toISOString().split('T')[0];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = '## Pagination Cap Hit (exactly 500 or 10,000)\n\n' +
+              'A repoll date returned a count that lands *exactly* on a known page-size (500) ' +
+              'or max-results (10,000) boundary — the classic signature of pagination silently ' +
+              'stopping early. The affected date(s) may be truncated.\n\n' +
+              '**Affected fetches:**\n```\n' + content + '\n```\n\n' +
+              '**Action:** Confirm the real total actually equals that number, or re-collect the date.\n\n' +
+              `[View the workflow run](${runUrl})`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Pagination Cap Hit (repoll) - ' + today,
+              body,
+              labels: ['bug', 'data-issue'],
+              assignees: ['abigailhaddad'],
+            });
+            fs.unlinkSync(capFile);
+          }
+
     - name: Alert if repoll did not finish its year
       if: always()
       uses: actions/github-script@v7

--- a/scripts/cap_alert.py
+++ b/scripts/cap_alert.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Tripwire for pagination caps.
+
+Landing *exactly* on a known page-size (500) or max-results ceiling (10,000)
+is the classic signature of pagination silently stopping — the API had more
+rows but we took only the first page/batch. Any collection that produces one
+of these exact counts appends a loud line to logs/CAP_HIT_WARNING.txt, which
+the daily and repoll workflows turn into a GitHub issue.
+
+False positives are possible (a query legitimately having exactly 500 rows),
+but we would rather investigate a harmless coincidence than ship truncated
+numbers.
+"""
+
+import os
+from datetime import datetime
+
+# Exact counts that mean "you probably hit a cap, not the real end".
+CAP_VALUES = {500, 10000}
+
+_MARKER = os.path.join(os.path.dirname(__file__), '..', 'logs', 'CAP_HIT_WARNING.txt')
+
+
+def check_cap(count, context):
+    """If `count` is exactly a known cap value, record it and return True.
+
+    `context` is a short human string describing what was being fetched
+    (e.g. "current jobs total" or "repoll date 2025-03-14").
+    """
+    try:
+        count = int(count)
+    except (TypeError, ValueError):
+        return False
+
+    if count in CAP_VALUES:
+        os.makedirs(os.path.dirname(_MARKER), exist_ok=True)
+        with open(_MARKER, 'a') as f:
+            f.write(f"{datetime.now().isoformat()} | {context} | count == {count} "
+                    f"(exact page/max-results boundary — possible silent truncation)\n")
+        print(f"🚨 CAP TRIPWIRE: {context} returned exactly {count} — "
+              f"logged to CAP_HIT_WARNING.txt for the workflow to alert on.")
+        return True
+    return False

--- a/scripts/collect_current_data.py
+++ b/scripts/collect_current_data.py
@@ -23,6 +23,7 @@ import os
 from tqdm import tqdm
 from html import unescape
 import re
+from cap_alert import check_cap
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -381,7 +382,14 @@ def fetch_all_jobs(params: Dict, headers: Dict, appointment_type_map: Dict[str, 
     
     progress_bar.close()
     print(f"✅ Fetched {len(raw_jobs)} total jobs across {page} pages")
-    
+
+    # Cap tripwire: hitting exactly max_results (10,000) or exactly the page
+    # size (500) usually means this query was truncated — the current API is
+    # segmented by occupational series precisely to stay under the 10k ceiling.
+    query_desc = params.get('JobCategoryCode') or params.get('Keyword') or 'current jobs query'
+    check_cap(len(raw_jobs), f"current fetch [{query_desc}] total")
+    check_cap(total_count, f"current fetch [{query_desc}] SearchResultCountAll")
+
     return raw_jobs, flattened_jobs
 
 

--- a/scripts/collect_data.py
+++ b/scripts/collect_data.py
@@ -20,6 +20,7 @@ import os
 from tqdm import tqdm
 import logging
 import sys
+from cap_alert import check_cap
 
 # Base URL for API requests
 
@@ -200,6 +201,11 @@ def fetch_all_pages(params: Dict, description: str = "") -> List[Dict]:
         alert_path = os.path.join(log_dir, 'PAGINATION_UNDER_COLLECTION.txt')
         with open(alert_path, 'a') as f:
             f.write(f"{description}: expected {expected_total}, got {len(all_jobs)} ({page_num} pages)\n")
+
+    # Cap tripwire: landing exactly on 500 (page size) or 10,000 may mean
+    # pagination stopped at a boundary rather than the true end.
+    check_cap(len(all_jobs), f"historical fetch [{description}] total")
+    check_cap(expected_total, f"historical fetch [{description}] totalCount")
 
     return all_jobs
 

--- a/scripts/repoll_status.py
+++ b/scripts/repoll_status.py
@@ -32,6 +32,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Set
 
+from cap_alert import check_cap
+
 DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
 
 FINAL_STATUSES = {'Candidate selected', 'Job canceled', 'Job closed'}
@@ -93,6 +95,10 @@ def fetch_all_for_date(date_str: str) -> List[Dict]:
             params = None
         else:
             break
+
+    # Cap tripwire: a single date returning exactly 500 (page size) or 10,000
+    # may mean pagination silently stopped instead of reaching the true end.
+    check_cap(len(all_jobs), f"repoll date {date_str}")
 
     return all_jobs
 


### PR DESCRIPTION
Adds a tripwire that screams when any collection returns *exactly* 500 (page size) or *exactly* 10,000 (max-results ceiling) — the classic signature of pagination silently stopping instead of reaching the true end.

- `cap_alert.check_cap(count, context)` → appends to `logs/CAP_HIT_WARNING.txt`.
- Wired into all three fetch paths: historical (`collect_data`), current per-series (`collect_current_data`), and repoll per-date (`repoll_status`).
- Both the daily and repoll workflows convert the marker into an assigned/labeled GitHub issue.

False positives are possible (a query legitimately having exactly that many rows) but preferred over silently truncated numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)