### PR TITLE
Auto-retry pipeline failures once before alerting

### DIFF
--- a/.github/workflows/notify-on-pipeline-failure.yml
+++ b/.github/workflows/notify-on-pipeline-failure.yml
@@ -56,10 +56,18 @@ jobs:
             }
 
   notify:
-    # Only act on genuine failures (skip success / cancelled), and only after
-    # the automatic retry has also failed (attempt >= 2). Attempt 1 failures
-    # are handled by the retry job above.
-    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt >= 2
+    # Fires once the automatic retry has also gone wrong (attempt >= 2).
+    # Attempt 1 failures are handled by the retry job above.
+    #
+    # `cancelled` counts here even though it is ignored on attempt 1, where it
+    # usually means a human stopped the run. On attempt 2 nobody asked for the
+    # run at all — it is a retry we started — so a cancellation is the retry
+    # dying, not a person changing their mind. Alerting only on 'failure' would
+    # trade attempt 1's alert for silence in that case, and cancellations are
+    # not rare here: 3 of the last 6 non-success daily runs ended cancelled.
+    # Kept on one line on purpose: a folded `if:` still evaluates, but a broken
+    # condition here fails silently (no alert, no error), so this stays boring.
+    if: (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled') && github.event.workflow_run.run_attempt >= 2
     runs-on: ubuntu-latest
     steps:
       - name: Open an issue for the failed run
@@ -85,10 +93,21 @@ jobs:
               return;
             }
 
+            // Attempt >= 2 means the original run failed and the automatic
+            // retry then failed or was cancelled. Say which, because they
+            // point at different things: a second failure suggests a real
+            // bug, a cancelled retry suggests the runner never got going.
+            const lead = run.conclusion === 'cancelled'
+              ? [`**${run.name}** failed, and the automatic retry was cancelled`,
+                 `rather than completing. Nobody requested this attempt, so the`,
+                 `cancellation is the retry dying — not a human stopping it.`,
+                 `The original failure is still unaddressed.`]
+              : [`**${run.name}** run failed twice: the original run and the`,
+                 `automatic retry. This is unlikely to be a transient runner`,
+                 `death — check the logs.`];
+
             const body = [
-              `**${run.name}** run failed twice: the original run and the`,
-              `automatic retry. This is unlikely to be a transient runner`,
-              `death — check the logs.`,
+              ...lead,
               ``,
               ``,
               `This alert comes from a separate watcher workflow, so it fires even`,

--- a/.github/workflows/notify-on-pipeline-failure.yml
+++ b/.github/workflows/notify-on-pipeline-failure.yml
@@ -16,11 +16,50 @@ on:
 
 permissions:
   issues: write
+  actions: write
 
 jobs:
+  retry:
+    # First failure of a run gets ONE automatic rerun. Runner deaths
+    # ("shutdown signal", OOM, lost communication) are transient and a plain
+    # rerun recovers them; a genuine bug just fails again on attempt 2 and
+    # the notify job below opens the issue. run_attempt == 1 is the loop
+    # guard: attempt 2's failure never triggers another rerun.
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun the failed jobs (one retry)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            try {
+              await github.rest.actions.reRunWorkflowFailedJobs({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+              console.log(`Requested rerun of failed jobs for "${run.name}" run ${run.id} (attempt 1 -> 2).`);
+            } catch (e) {
+              // If the rerun can't be started, don't fail silently — open the
+              // issue now instead of waiting for an attempt 2 that won't come.
+              console.log(`Rerun request failed: ${e.message} — opening issue instead.`);
+              const date = new Date().toISOString().split('T')[0];
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `${run.name} Failed - ${date}`,
+                body: `**${run.name}** failed and the automatic rerun could not be started (${e.message}).\n\n[View the failed run](${run.html_url})`,
+                labels: ['bug', 'automated', 'pipeline-failure'],
+                assignees: ['abigailhaddad'],
+              });
+            }
+
   notify:
-    # Only act on genuine failures (skip success / cancelled).
-    if: github.event.workflow_run.conclusion == 'failure'
+    # Only act on genuine failures (skip success / cancelled), and only after
+    # the automatic retry has also failed (attempt >= 2). Attempt 1 failures
+    # are handled by the retry job above.
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt >= 2
     runs-on: ubuntu-latest
     steps:
       - name: Open an issue for the failed run
@@ -47,7 +86,10 @@ jobs:
             }
 
             const body = [
-              `**${run.name}** run failed.`,
+              `**${run.name}** run failed twice: the original run and the`,
+              `automatic retry. This is unlikely to be a transient runner`,
+              `death — check the logs.`,
+              ``,
               ``,
               `This alert comes from a separate watcher workflow, so it fires even`,
               `when the runner is killed mid-run (OOM / lost communication) and the`,


### PR DESCRIPTION
Attempt-1 failures of the Daily Data Update / Repoll workflows (runner deaths like this morning's exit-143, OOM, lost communication) now get one automatic rerun of the failed jobs. The failure issue only opens if the retry also fails (attempt >= 2). If the rerun API call itself errors, the issue opens immediately.

Loop guard: retries fire only on run_attempt == 1, so a genuinely broken run fails at most twice and alerts once.

Context: this morning's Daily Data Update completed its fetch, then the GitHub runner received a shutdown signal before the R2 sync. A manual rerun recovered it in 18 minutes; this makes that recovery automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsdPjeMbjjo7D9b4cYU8GG