### PR TITLE
Stop loading whole parquet files to read one column (fixes daily update OOM)

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -147,8 +147,12 @@ jobs:
         BACKFILL_START_DATE: ${{ inputs.backfill_start_date }}
         BACKFILL_END_DATE: ${{ inputs.backfill_end_date }}
       run: |
+        free -h || true
         cd update
-        python update_all.py
+        # -u: unbuffered. When the runner gets OOM-killed mid-step, buffered
+        # progress output dies with it and the log just stops with no clue
+        # which phase was running. Unbuffered output survives the kill.
+        python -u update_all.py
 
     - name: Check for Current API warning
       if: always()

--- a/scripts/collect_current_data.py
+++ b/scripts/collect_current_data.py
@@ -18,6 +18,7 @@ import time
 import requests
 from typing import List, Dict, Optional
 import pandas as pd
+import pyarrow.parquet as pq
 from datetime import datetime
 import os
 from tqdm import tqdm
@@ -196,10 +197,15 @@ def flatten_current_job(job_item: dict, appointment_type_map: dict, hiring_path_
 
 
 def load_existing_jobs(parquet_path: str) -> set:
-    """Load existing control numbers from parquet file"""
+    """Load existing control numbers from parquet file.
+
+    Reads ONLY the control number column. These files are gigabytes of job
+    description text; loading them whole to get one column is what was
+    OOM-killing the daily update runner.
+    """
     if os.path.exists(parquet_path):
         try:
-            df = pd.read_parquet(parquet_path)
+            df = pd.read_parquet(parquet_path, columns=['usajobsControlNumber'])
             return set(df['usajobsControlNumber'].dropna().astype(str))
         except Exception as e:
             print(f"⚠️ Warning: Could not read existing parquet file {parquet_path}: {e}")
@@ -666,13 +672,17 @@ def main():
             save_jobs_to_parquet(new_jobs, parquet_path)
             total_new_jobs += len(new_jobs)
         
-        # Show stats for this year
+        # Show stats for this year (row count from metadata, one column for the
+        # open count — never load the whole file just to print two numbers)
         if os.path.exists(parquet_path):
             try:
-                df = pd.read_parquet(parquet_path)
-                total_current = len(df)
-                open_jobs = len(df[df['positionOpeningStatus'] == 'Open']) if 'positionOpeningStatus' in df.columns else 0
-                
+                total_current = pq.read_metadata(parquet_path).num_rows
+                if 'positionOpeningStatus' in pq.read_schema(parquet_path).names:
+                    status = pd.read_parquet(parquet_path, columns=['positionOpeningStatus'])
+                    open_jobs = int((status['positionOpeningStatus'] == 'Open').sum())
+                else:
+                    open_jobs = 0
+
                 print(f"   ✅ {year} parquet file now contains:")
                 print(f"      - {total_current:,} total current jobs")
                 print(f"      - {open_jobs:,} open positions")

--- a/scripts/collect_data.py
+++ b/scripts/collect_data.py
@@ -15,6 +15,7 @@ import time
 import requests
 from typing import List, Dict, Optional
 import pandas as pd
+import pyarrow.parquet as pq
 from datetime import datetime, timedelta
 import os
 from tqdm import tqdm
@@ -300,17 +301,23 @@ def fetch_jobs_for_date(date: str, position_series: Optional[str] = None) -> tup
 
 
 def load_existing_jobs(parquet_path: str) -> set:
-    """Load existing job control numbers from parquet file."""
+    """Load existing job control numbers from parquet file.
+
+    Reads ONLY the control number column — these files are mostly job
+    description text, and loading them whole here is pure memory waste.
+    """
     try:
-        df = pd.read_parquet(parquet_path)
+        names = pq.read_schema(parquet_path).names
         # Use usajobs_control_number if available (consistent with current script), otherwise fall back
-        if 'usajobs_control_number' in df.columns:
-            return set(df['usajobs_control_number'].dropna().astype(str))
-        elif 'usajobsControlNumber' in df.columns:
-            return set(df['usajobsControlNumber'].dropna().astype(str))
+        if 'usajobs_control_number' in names:
+            col = 'usajobs_control_number'
+        elif 'usajobsControlNumber' in names:
+            col = 'usajobsControlNumber'
         else:
             return set()
-    except (FileNotFoundError, KeyError):
+        df = pd.read_parquet(parquet_path, columns=[col])
+        return set(df[col].dropna().astype(str))
+    except (FileNotFoundError, KeyError, OSError):
         return set()
 
 
@@ -631,8 +638,8 @@ def main():
     for year in range(2015, datetime.now().year + 2):
         parquet_path = f"{args.data_dir}/historical_jobs_{year}.parquet"
         if os.path.exists(parquet_path):
-            df = pd.read_parquet(parquet_path)
-            print(f"  historical_jobs_{year}.parquet: {len(df):,} jobs")
+            n_jobs = pq.read_metadata(parquet_path).num_rows
+            print(f"  historical_jobs_{year}.parquet: {n_jobs:,} jobs")
 
 
 if __name__ == "__main__":

--- a/update/generate_docs_data.py
+++ b/update/generate_docs_data.py
@@ -11,11 +11,24 @@ Usage:
 """
 
 import pandas as pd
+import pyarrow.parquet as pq
 import json
 import os
 import glob
 from datetime import datetime
 import numpy as np
+
+# The current_jobs parquet files are gigabytes of job-description text. Reading
+# them whole to count rows or scan one column is what OOM-killed the daily
+# update runner, so everything here reads metadata or projects columns.
+
+def read_cols(path, cols):
+    """Read only `cols` that actually exist in the file; None if none do."""
+    names = pq.read_schema(path).names
+    present = [c for c in cols if c in names]
+    if not present:
+        return None
+    return pd.read_parquet(path, columns=present)
 
 def get_field_examples(series, field_name, max_examples=4):
     """Get representative examples for a field, showing variety when possible"""
@@ -87,28 +100,26 @@ def analyze_data_coverage():
         jobs_opened = 0
         jobs_closed = 0
         
-        # Historical data
-        if os.path.exists(hist_file):
-            df = pd.read_parquet(hist_file)
-            total_jobs += len(df)
-            
-            # Count jobs opened/closed by date parsing
-            df['positionOpenDate'] = pd.to_datetime(df['positionOpenDate'], errors='coerce')
-            df['positionCloseDate'] = pd.to_datetime(df['positionCloseDate'], errors='coerce')
-            
-            jobs_opened += len(df[df['positionOpenDate'].dt.year == year])
-            jobs_closed += len(df[df['positionCloseDate'].dt.year == year])
-        
-        # Current data  
-        if os.path.exists(curr_file):
-            df_curr = pd.read_parquet(curr_file)
-            total_jobs += len(df_curr)
-            
-            df_curr['positionOpenDate'] = pd.to_datetime(df_curr['positionOpenDate'], errors='coerce')
-            df_curr['positionCloseDate'] = pd.to_datetime(df_curr['positionCloseDate'], errors='coerce')
-            
-            jobs_opened += len(df_curr[df_curr['positionOpenDate'].dt.year == year])
-            jobs_closed += len(df_curr[df_curr['positionCloseDate'].dt.year == year])
+        for path in (hist_file, curr_file):
+            if not os.path.exists(path):
+                continue
+
+            total_jobs += pq.read_metadata(path).num_rows
+
+            # Count jobs opened/closed by date parsing — only the two date
+            # columns get loaded, not the whole announcement text.
+            dates = read_cols(path, ['positionOpenDate', 'positionCloseDate'])
+            if dates is None:
+                continue
+            for col, bucket in (('positionOpenDate', 'opened'), ('positionCloseDate', 'closed')):
+                if col not in dates.columns:
+                    continue
+                parsed = pd.to_datetime(dates[col], errors='coerce')
+                n = int((parsed.dt.year == year).sum())
+                if bucket == 'opened':
+                    jobs_opened += n
+                else:
+                    jobs_closed += n
         
         # Determine coverage notes
         if year <= 2016:
@@ -139,12 +150,24 @@ def analyze_data_coverage():
     return coverage_data
 
 def analyze_all_fields():
-    """Analyze all fields from the most recent complete year (2024)"""
-    df = pd.read_parquet('../data/historical_jobs_2024.parquet')
-    
+    """Analyze all fields from the most recent complete year (2024)
+
+    One column at a time: peak memory is a single column, not the whole file.
+    """
+    path = '../data/historical_jobs_2024.parquet'
+    schema = pq.read_schema(path)
+    n_rows = pq.read_metadata(path).num_rows
+
+    # A stored pandas index shows up in the arrow schema but never was a
+    # column in the old full-DataFrame read — don't document it as a field.
+    col_names = [c for c in schema.names if not c.startswith('__index_level_')]
+
     field_data = []
-    
-    for col in sorted(df.columns):
+
+    for col_name in sorted(col_names):
+        df = pd.read_parquet(path, columns=[col_name])
+        col = col_name  # keep the rest of the loop reading as before
+
         # Determine data type
         dtype = str(df[col].dtype)
         if dtype == 'object':
@@ -164,7 +187,7 @@ def analyze_all_fields():
             field_type = "String"
         
         # Calculate completeness
-        completeness = (df[col].notna().sum() / len(df)) * 100
+        completeness = (df[col].notna().sum() / n_rows) * 100 if n_rows else 0
         
         # Get examples
         examples, unique_count = get_field_examples(df[col], col)
@@ -208,11 +231,10 @@ def get_latest_date():
     all_files = glob.glob('../data/historical_jobs_*.parquet') + glob.glob('../data/current_jobs_*.parquet')
     
     for file in all_files:
-        df = pd.read_parquet(file)
-        if 'inserted_at' in df.columns:
-            df['inserted_at'] = pd.to_datetime(df['inserted_at'], errors='coerce')
-            file_latest = df['inserted_at'].max()
-            
+        df = read_cols(file, ['inserted_at'])
+        if df is not None:
+            file_latest = pd.to_datetime(df['inserted_at'], errors='coerce').max()
+
             if pd.notna(file_latest) and (latest_date is None or file_latest > latest_date):
                 latest_date = file_latest
     
@@ -227,8 +249,7 @@ def generate_docs_data():
     total_jobs = 0
     
     for file in all_files:
-        df = pd.read_parquet(file)
-        total_jobs += len(df)
+        total_jobs += pq.read_metadata(file).num_rows
     
     # Generate all data
     coverage_data = analyze_data_coverage()

--- a/update/test_data_integrity.py
+++ b/update/test_data_integrity.py
@@ -32,26 +32,26 @@ def check_parquet_file(filepath, min_rows, required_columns, description):
         return False
 
     try:
-        # Check if file is valid parquet
+        # Check if file is valid parquet. Row count and column names both come
+        # from the footer — these files are gigabytes of announcement text and
+        # don't need to be loaded into pandas to be checked.
         pq_file = pq.ParquetFile(filepath)
-        schema = pq_file.schema
-
-        # Read the data
-        df = pd.read_parquet(filepath)
+        n_rows = pq_file.metadata.num_rows
+        columns = pq_file.schema_arrow.names
 
         # Check row count
-        if len(df) < min_rows:
+        if n_rows < min_rows:
             print(f"{Colors.RED}❌ FAIL{Colors.RESET} {description}")
-            print(f"     Expected at least {min_rows} rows, found {len(df)}")
+            print(f"     Expected at least {min_rows} rows, found {n_rows}")
             return False
 
         # Check columns
-        missing_cols = [col for col in required_columns if col not in df.columns]
+        missing_cols = [col for col in required_columns if col not in columns]
         if missing_cols:
             print(f"{Colors.RED}❌ FAIL{Colors.RESET} {description} - Missing columns: {missing_cols}")
             return False
 
-        print(f"{Colors.GREEN}✅ PASS{Colors.RESET} {description} ({len(df):,} rows)")
+        print(f"{Colors.GREEN}✅ PASS{Colors.RESET} {description} ({n_rows:,} rows)")
         return True
 
     except Exception as e:
@@ -62,15 +62,17 @@ def check_parquet_file(filepath, min_rows, required_columns, description):
 def check_data_recency(filepath, max_days_old, description):
     """Check if data is recent enough"""
     try:
-        df = pd.read_parquet(filepath)
+        # Pick the date column from the schema, then load only that column.
+        available = pq.ParquetFile(filepath).schema_arrow.names
 
-        # Check if there's a date column
         date_columns = ['DatePosted', 'date_posted', 'PositionOpenDate', 'ApplicationCloseDate', 'applicationCloseDate', 'positionOpenDate']
         date_col = None
         for col in date_columns:
-            if col in df.columns:
+            if col in available:
                 date_col = col
                 break
+
+        df = pd.read_parquet(filepath, columns=[date_col]) if date_col else None
 
         if not date_col:
             print(f"{Colors.YELLOW}⚠️  WARN{Colors.RESET} {description} - No date column found")
@@ -120,8 +122,7 @@ def check_no_data_loss():
         filepath = f"../data/{filename}"
         if os.path.exists(filepath):
             try:
-                df = pd.read_parquet(filepath)
-                current_count = len(df)
+                current_count = pq.ParquetFile(filepath).metadata.num_rows
 
                 if current_count < baseline_count:
                     print(f"{Colors.RED}❌ FAIL{Colors.RESET} {filename} shrunk: {baseline_count} → {current_count}")
@@ -268,18 +269,21 @@ def check_data_consistency():
         if not os.path.exists(historical_file):
             historical_file = f'../data/historical_jobs_{current_year - 1}.parquet'
 
-        current_df = pd.read_parquet(current_file)
-        historical_df = pd.read_parquet(historical_file)
+        def load_ids(path):
+            """Load just the ID column, preferring PositionID, then control
+            number — loading the full file here is what OOM'd the runner."""
+            available = pq.ParquetFile(path).schema_arrow.names
+            ids = set()
+            if 'PositionID' in available:
+                ids = set(pd.read_parquet(path, columns=['PositionID'])['PositionID'].unique())
+            # Check for control numbers if PositionID doesn't exist
+            if not ids and 'usajobsControlNumber' in available:
+                ids = set(pd.read_parquet(path, columns=['usajobsControlNumber'])['usajobsControlNumber'].unique())
+            return ids
 
         # Current should be subset of or equal to historical for same year
-        current_ids = set(current_df['PositionID'].unique()) if 'PositionID' in current_df.columns else set()
-        historical_ids = set(historical_df['PositionID'].unique()) if 'PositionID' in historical_df.columns else set()
-
-        # Check for control numbers if PositionID doesn't exist
-        if not current_ids and 'usajobsControlNumber' in current_df.columns:
-            current_ids = set(current_df['usajobsControlNumber'].unique())
-        if not historical_ids and 'usajobsControlNumber' in historical_df.columns:
-            historical_ids = set(historical_df['usajobsControlNumber'].unique())
+        current_ids = load_ids(current_file)
+        historical_ids = load_ids(historical_file)
 
         if current_ids and historical_ids:
             missing_in_historical = current_ids - historical_ids


### PR DESCRIPTION
Fixes the recurring `Daily Data Update` failures (#506, plus 8/3 and 7/24).

## Diagnosis

The runner was **OOM-killed**, not failing on a code error — "lost communication" on 8/5 and 7/24, and exit code 143 (SIGTERM) on 8/3, where collection finished cleanly at 08:56, went silent for 11 minutes, and died at 09:07.

Nothing changed in the code. The data outgrew the runner: `current_jobs_2026.parquet` is now **1.18 GB** compressed and `current_jobs_2025.parquet` **674 MB**, almost entirely announcement text, which expands severalfold once pandas materializes it. We called bare `pd.read_parquet(path)` — every column — in ten places, most of which only wanted a row count or one column to scan.

That's why it's intermittent (7/24, 8/3, 8/5 failed; the days between passed) and why it would keep getting worse.

## Changes

Full loads replaced with footer metadata (`num_rows`, schema names) or column projection:

| file | reads fixed |
|---|---|
| `scripts/collect_current_data.py` | `load_existing_jobs` (whole 1.18 GB file → one ID column); per-year stats print |
| `scripts/collect_data.py` | `load_existing_jobs`; final per-year summary counts |
| `update/generate_docs_data.py` | all three full sweeps of every file; `analyze_all_fields` reads one column at a time |
| `update/test_data_integrity.py` | validity, recency, shrink, and consistency checks |

Also runs `update_all.py` under `python -u`. Its progress output was block-buffered, so when the runner was killed the buffer died with it and the log simply stopped — which is why the failing phase was undiagnosable from the logs. Added a `free -h` before the step too.

## Verification

- `generate_docs_data.py` — **byte-identical** output old vs new on synthetic data
- `test_data_integrity.py` — **identical** output old vs new (fixed `PYTHONHASHSEED`; the initial diff was only set-iteration order)
- Peak RSS, full docs generation: **1176 MB → 117 MB**, on a test dir whose `current_jobs` files are 13 MB each — the real ones are 50–90x that
- Single read, measured: 614 MB → 107 MB, against a ~95 MB interpreter baseline

## Known remaining ceiling

`save_jobs_to_parquet` still does a full read + `concat` + rewrite of the 1.18 GB file. That one genuinely needs the data, it survived on 8/3 so it's under the ceiling today, and it grows every day. Fixing it means an arrow-native append or month-partitioning `current_jobs_2026` — a real refactor with data-loss risk, so it's deliberately not in this emergency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)