### PR TITLE
Survive R2 flaking during the daily sync

### DIFF
--- a/scripts/sync_to_r2.py
+++ b/scripts/sync_to_r2.py
@@ -26,11 +26,35 @@ import argparse
 import glob
 import os
 import sys
+import time
 
 import boto3
+from boto3.s3.transfer import TransferConfig
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
 
 
 BUCKET = "usajobs-data"
+
+# current_jobs_2026.parquet passed 1.2 GB in August 2026 and grows ~10 MB/day.
+# At boto3's default 8 MB chunk that is ~150 parts per upload, and R2 fails
+# CompleteMultipartUpload more often the more parts it has to assemble (it took
+# down the 2026-08-08 sync). Bigger chunks mean an order of magnitude fewer
+# parts and far fewer chances to flake.
+_CHUNK_SIZE = 64 * 1024 * 1024
+TRANSFER_CONFIG = TransferConfig(
+    multipart_threshold=_CHUNK_SIZE,
+    multipart_chunksize=_CHUNK_SIZE,
+)
+
+# boto3's default retry mode is 'legacy', which gives up after 4 attempts --
+# that is the "reached max retries: 4" in the 2026-08-08 failure.
+BOTO_CONFIG = Config(retries={"max_attempts": 10, "mode": "standard"})
+
+# Retries above boto3's own, because a failed CompleteMultipartUpload needs the
+# whole transfer restarted rather than the single request retried.
+_UPLOAD_ATTEMPTS = 4
+_BACKOFF_SECONDS = 5
 
 
 def get_r2_client():
@@ -55,14 +79,31 @@ def get_r2_client():
         endpoint_url=endpoint,
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
+        config=BOTO_CONFIG,
     )
 
 
 def upload_file(client, local_path, r2_key):
-    size = os.path.getsize(local_path)
-    size_mb = size / (1024 * 1024)
-    print(f"  Uploading {local_path} -> {r2_key} ({size_mb:.1f} MB)")
-    client.upload_file(local_path, BUCKET, r2_key)
+    """Upload one file, retrying the whole transfer on a transient R2 error.
+
+    Returns True on success. Raising here would abandon every file after this
+    one, so a flake on a single parquet must not end the sync.
+    """
+    size_mb = os.path.getsize(local_path) / (1024 * 1024)
+    print(f"  Uploading {local_path} -> {r2_key} ({size_mb:.1f} MB)", flush=True)
+
+    for attempt in range(1, _UPLOAD_ATTEMPTS + 1):
+        try:
+            client.upload_file(local_path, BUCKET, r2_key, Config=TRANSFER_CONFIG)
+            return True
+        except (ClientError, BotoCoreError) as e:
+            if attempt == _UPLOAD_ATTEMPTS:
+                print(f"    FAILED after {attempt} attempts: {e}", file=sys.stderr, flush=True)
+                return False
+            delay = _BACKOFF_SECONDS * (2 ** (attempt - 1))
+            print(f"    attempt {attempt} failed ({e}); retrying in {delay}s",
+                  file=sys.stderr, flush=True)
+            time.sleep(delay)
 
 
 def main():
@@ -81,38 +122,49 @@ def main():
 
     client = get_r2_client()
 
-    # Upload data/*.parquet files
+    uploaded = 0
+    failed = []
+
+    def send(local_path, r2_key):
+        nonlocal uploaded
+        if upload_file(client, local_path, r2_key):
+            uploaded += 1
+        else:
+            failed.append(r2_key)
+
+    # The website reads web/jobs_5yr.parquet and web/static.json, and nothing
+    # else here. Upload them FIRST: on 2026-08-08 an R2 flake partway through
+    # the data/ loop aborted the sync before these two were sent, so the site
+    # served day-old data even though it had been generated successfully.
+    if os.path.exists(args.web_parquet):
+        print("Uploading web parquet:")
+        send(args.web_parquet, "web/jobs_5yr.parquet")
+    else:
+        print(f"Warning: web parquet not found at {args.web_parquet}", file=sys.stderr)
+
+    static_path = os.path.join(os.path.dirname(args.web_parquet), "static.json")
+    if os.path.exists(static_path):
+        print("\nUploading static data:")
+        send(static_path, "web/static.json")
+
+    # Then the per-year source files.
     pattern = os.path.join(args.data_dir, "*.parquet")
     parquet_files = sorted(glob.glob(pattern))
 
     if not parquet_files:
         print(f"Warning: no parquet files found in {args.data_dir}/", file=sys.stderr)
 
-    uploaded = 0
-
-    print(f"Uploading data parquet files from {args.data_dir}/:")
+    print(f"\nUploading data parquet files from {args.data_dir}/:")
     for path in parquet_files:
-        filename = os.path.basename(path)
-        r2_key = f"data/{filename}"
-        upload_file(client, path, r2_key)
-        uploaded += 1
-
-    # Upload web parquet
-    if os.path.exists(args.web_parquet):
-        print(f"\nUploading web parquet:")
-        upload_file(client, args.web_parquet, "web/jobs_5yr.parquet")
-        uploaded += 1
-    else:
-        print(f"Warning: web parquet not found at {args.web_parquet}", file=sys.stderr)
-
-    # Upload static.json for instant page load
-    static_path = os.path.join(os.path.dirname(args.web_parquet), "static.json")
-    if os.path.exists(static_path):
-        print(f"\nUploading static data:")
-        upload_file(client, static_path, "web/static.json")
-        uploaded += 1
+        send(path, f"data/{os.path.basename(path)}")
 
     print(f"\nDone. {uploaded} file(s) uploaded to r2://{BUCKET}/")
+
+    if failed:
+        print(f"\n{len(failed)} file(s) FAILED to upload:", file=sys.stderr)
+        for key in failed:
+            print(f"  - {key}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #512. The 2026-08-08 run collected everything correctly — collection, integrity tests, prep web data, and API tests all passed — then died in **Sync to R2**:

```
botocore.exceptions.ClientError: An error occurred (InternalError) when calling
the CompleteMultipartUpload operation (reached max retries: 4):
We encountered an internal error. Please try again.
```

R2 failing server-side while assembling a multipart upload. Nothing wrong with the data or the code — but three things turned a transient cloud error into a failed pipeline *and* a stale website.

## 1. Upload order stranded the site

The website reads `web/jobs_5yr.parquet` and `web/static.json`, and nothing else. Those were uploaded **last**, after every `data/*.parquet`. The flake hit partway through the `data/` loop, so the freshly generated web files were never sent — the site served day-old data even though today's had been built successfully.

Web files now go first.

## 2. One failure killed the whole run

`upload_file` let the exception escape, so the first bad file abandoned every file after it. Failures are now collected and reported at the end, and the script still exits non-zero — but a flake on one parquet no longer strands the rest.

## 3. Too many parts

`current_jobs_2026.parquet` is **1.2 GB** and grows ~10 MB/day. At boto3's default 8 MB chunk that's ~150 parts per upload, and `CompleteMultipartUpload` gets less reliable the more parts R2 has to assemble. 64 MB chunks cut it to ~19.

Also switched the client off boto3's `legacy` retry mode (4 attempts — the "max retries: 4" above) to `standard` with 10, and added an outer retry with exponential backoff, since a failed multipart completion needs the whole transfer restarted rather than the single request retried.

## Testing

Against a stubbed client reproducing the exact 8/8 `InternalError` — 11 assertions, all passing:

- happy path: web files upload **before** any `data/` file; all files sent; exit 0
- 64 MB chunk config reaches **every** upload call
- persistent failure on a `data/` file: web files still go first, later files **still upload**, retried 4x, exits **non-zero**
- transient failure (fails twice, then succeeds): recovers on the 3rd attempt, exit 0
- failure on the web parquet itself: `data/` uploads still proceed, exits non-zero

## Note

This treats the symptom. The root cause underneath is `current_jobs_2026.parquet` growing without bound — the same file behind the OOM in #507 and now this. Month-partitioning it, or an arrow-native append, would fix both properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)