### PR TITLE
Sync only the parquet files that actually changed

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -195,6 +195,12 @@ jobs:
         print(f'R2 download validated: all historical files present and non-empty')
         "
 
+    # Record what every parquet looked like before collection touches it, so
+    # the sync at the end can skip the ones nothing wrote. Must run after the
+    # download and before update_all.py. Needs no R2 credentials.
+    - name: Snapshot data baseline for changed-only sync
+      run: python scripts/sync_to_r2.py --snapshot
+
     - name: Run daily data update
       if: inputs.skip_collection != true
       env:
@@ -411,7 +417,7 @@ jobs:
         R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
       run: |
-        python scripts/sync_to_r2.py
+        python scripts/sync_to_r2.py --only-changed
 
     - name: Create Pull Request
       if: env.CHANGES_MADE == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ download/*.duckdb
 
 # Data files - Parquet and precomputed data (stored in Cloudflare R2, not in git)
 data/*.parquet
+# Baseline written by `sync_to_r2.py --snapshot`; local to a pipeline run.
+data/.r2_baseline.json
 web/data/*.parquet
 web/data/static.json
 

--- a/scripts/sync_to_r2.py
+++ b/scripts/sync_to_r2.py
@@ -24,6 +24,7 @@ GitHub Actions integration:
 
 import argparse
 import glob
+import json
 import os
 import sys
 import time
@@ -35,6 +36,12 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 
 BUCKET = "usajobs-data"
+
+# Where --snapshot records what the data files looked like straight after the
+# R2 download, so --only-changed can tell which ones collection actually wrote.
+# Dot-prefixed and .json, so it matches neither the "*.parquet" upload glob nor
+# anything the workflow commits. Also listed in .gitignore.
+BASELINE_NAME = ".r2_baseline.json"
 
 # current_jobs_2026.parquet passed 1.2 GB in August 2026 and grows ~10 MB/day.
 # At boto3's default 8 MB chunk that is ~150 parts per upload, and R2 fails
@@ -55,6 +62,55 @@ BOTO_CONFIG = Config(retries={"max_attempts": 10, "mode": "standard"})
 # whole transfer restarted rather than the single request retried.
 _UPLOAD_ATTEMPTS = 4
 _BACKOFF_SECONDS = 5
+
+
+def _fingerprint(path):
+    """(size, mtime_ns) — enough to tell whether our own pipeline rewrote a file.
+
+    Only this pipeline writes these files during a run, and every writer either
+    creates the file or renames a fresh temp over it, so a rewrite always moves
+    mtime. A rewrite that produced byte-identical content would still be
+    re-uploaded, which is the harmless direction to be wrong in.
+    """
+    st = os.stat(path)
+    return {"size": st.st_size, "mtime_ns": st.st_mtime_ns}
+
+
+def write_baseline(data_dir):
+    """Record the post-download state of data/*.parquet. Needs no R2 access."""
+    files = sorted(glob.glob(os.path.join(data_dir, "*.parquet")))
+    baseline = {os.path.basename(p): _fingerprint(p) for p in files}
+
+    path = os.path.join(data_dir, BASELINE_NAME)
+    with open(path, "w") as f:
+        json.dump(baseline, f, indent=2, sort_keys=True)
+
+    total_mb = sum(e["size"] for e in baseline.values()) / (1024 * 1024)
+    print(f"Baseline written to {path}: {len(baseline)} file(s), {total_mb:,.1f} MB")
+    return 0
+
+
+def load_baseline(data_dir):
+    """Return the recorded baseline, or None if it is missing or unusable.
+
+    None means "upload everything". Skipping an upload because we could not
+    read the baseline would leave stale data in R2 with no error, so every
+    failure path here has to fall back to the current, safe behaviour.
+    """
+    path = os.path.join(data_dir, BASELINE_NAME)
+    if not os.path.exists(path):
+        print(f"Warning: {path} not found — uploading every file.", file=sys.stderr)
+        return None
+    try:
+        with open(path) as f:
+            baseline = json.load(f)
+        if not isinstance(baseline, dict):
+            raise ValueError("baseline is not an object")
+        return baseline
+    except (OSError, ValueError) as e:
+        print(f"Warning: could not read {path} ({e}) — uploading every file.",
+              file=sys.stderr)
+        return None
 
 
 def get_r2_client():
@@ -118,7 +174,25 @@ def main():
         default="web/data/jobs_5yr.parquet",
         help="Path to web parquet file (default: web/data/jobs_5yr.parquet)",
     )
+    parser.add_argument(
+        "--snapshot",
+        action="store_true",
+        help="Record the current state of data/*.parquet and exit. Run this "
+             "right after downloading from R2, before collection rewrites "
+             "anything. Requires no R2 credentials.",
+    )
+    parser.add_argument(
+        "--only-changed",
+        action="store_true",
+        help="Skip data files that are byte-for-byte what --snapshot recorded. "
+             "Falls back to uploading everything if the baseline is missing.",
+    )
     args = parser.parse_args()
+
+    if args.snapshot:
+        return write_baseline(args.data_dir)
+
+    baseline = load_baseline(args.data_dir) if args.only_changed else None
 
     client = get_r2_client()
 
@@ -155,8 +229,21 @@ def main():
         print(f"Warning: no parquet files found in {args.data_dir}/", file=sys.stderr)
 
     print(f"\nUploading data parquet files from {args.data_dir}/:")
+    skipped = 0
+    skipped_bytes = 0
     for path in parquet_files:
-        send(path, f"data/{os.path.basename(path)}")
+        name = os.path.basename(path)
+        # A file absent from the baseline is new (e.g. the first file of a new
+        # year), so it must be uploaded.
+        if baseline is not None and baseline.get(name) == _fingerprint(path):
+            skipped += 1
+            skipped_bytes += os.path.getsize(path)
+            print(f"  Unchanged, skipping {name}")
+            continue
+        send(path, f"data/{name}")
+
+    if skipped:
+        print(f"\nSkipped {skipped} unchanged file(s), {skipped_bytes / (1024 * 1024):,.1f} MB not re-uploaded.")
 
     print(f"\nDone. {uploaded} file(s) uploaded to r2://{BUCKET}/")
 

--- a/scripts/tests/test_sync_baseline.py
+++ b/scripts/tests/test_sync_baseline.py
@@ -1,0 +1,111 @@
+"""Tests for sync_to_r2.py — the --snapshot / --only-changed baseline.
+
+The dangerous failure here is skipping a file that DID change: R2 would keep
+serving stale data and nothing would error. So the cases that matter most are
+the ones asserting a file is *not* skipped.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from sync_to_r2 import BASELINE_NAME, _fingerprint, load_baseline, write_baseline
+
+
+def _write(path, content=b"x"):
+    with open(path, "wb") as f:
+        f.write(content)
+    return path
+
+
+def _touch_content(path, content):
+    """Rewrite a file so both its size and mtime move, as a real rewrite does."""
+    st_before = os.stat(path).st_mtime_ns
+    with open(path, "wb") as f:
+        f.write(content)
+    # Guarantee a distinct mtime even on a coarse-grained filesystem.
+    os.utime(path, ns=(st_before + 1_000_000, st_before + 1_000_000))
+
+
+def test_unchanged_file_matches_baseline(tmp_path):
+    d = str(tmp_path)
+    p = _write(os.path.join(d, "historical_jobs_2020.parquet"), b"unchanged")
+
+    write_baseline(d)
+    baseline = load_baseline(d)
+
+    assert baseline["historical_jobs_2020.parquet"] == _fingerprint(p)
+
+
+def test_rewritten_file_does_not_match(tmp_path):
+    d = str(tmp_path)
+    p = _write(os.path.join(d, "current_jobs_2026.parquet"), b"before")
+
+    write_baseline(d)
+    baseline = load_baseline(d)
+    _touch_content(p, b"after-and-longer")
+
+    assert baseline["current_jobs_2026.parquet"] != _fingerprint(p)
+
+
+def test_same_size_but_new_mtime_does_not_match(tmp_path):
+    """A rewrite that happens to preserve byte count must still be uploaded."""
+    d = str(tmp_path)
+    p = _write(os.path.join(d, "current_jobs_2025.parquet"), b"aaaa")
+
+    write_baseline(d)
+    baseline = load_baseline(d)
+    _touch_content(p, b"bbbb")  # identical length, different content
+
+    assert os.path.getsize(p) == baseline["current_jobs_2025.parquet"]["size"]
+    assert baseline["current_jobs_2025.parquet"] != _fingerprint(p)
+
+
+def test_new_file_is_absent_from_baseline(tmp_path):
+    """January's brand-new year file has no baseline entry, so it uploads."""
+    d = str(tmp_path)
+    _write(os.path.join(d, "historical_jobs_2026.parquet"))
+    write_baseline(d)
+    baseline = load_baseline(d)
+
+    new = _write(os.path.join(d, "historical_jobs_2027.parquet"))
+    assert baseline.get("historical_jobs_2027.parquet") is None
+    assert baseline.get("historical_jobs_2027.parquet") != _fingerprint(new)
+
+
+def test_missing_baseline_returns_none(tmp_path, capsys):
+    """No baseline must mean 'upload everything', never 'skip everything'."""
+    assert load_baseline(str(tmp_path)) is None
+    assert "uploading every file" in capsys.readouterr().err
+
+
+def test_corrupt_baseline_returns_none(tmp_path, capsys):
+    d = str(tmp_path)
+    with open(os.path.join(d, BASELINE_NAME), "w") as f:
+        f.write("{not json")
+
+    assert load_baseline(d) is None
+    assert "uploading every file" in capsys.readouterr().err
+
+
+def test_non_object_baseline_returns_none(tmp_path):
+    d = str(tmp_path)
+    with open(os.path.join(d, BASELINE_NAME), "w") as f:
+        json.dump(["not", "a", "dict"], f)
+
+    assert load_baseline(d) is None
+
+
+def test_baseline_only_covers_parquet(tmp_path):
+    """The baseline file itself must never end up in its own manifest."""
+    d = str(tmp_path)
+    _write(os.path.join(d, "historical_jobs_2019.parquet"))
+    _write(os.path.join(d, "notes.txt"))
+
+    write_baseline(d)
+    baseline = load_baseline(d)
+
+    assert set(baseline) == {"historical_jobs_2019.parquet"}
+    assert BASELINE_NAME not in baseline


### PR DESCRIPTION
Stacked on #519 — merge that one first, then this. Targeting `workflow-runner-resilience` so each PR shows only its own diff.

`sync_to_r2.py` uploads `glob("data/*.parquet")` unconditionally, so every run re-sends the entire dataset.

## The numbers (measured against R2 today)

| File | Size | Changes daily? |
|---|---|---|
| `current_jobs_2025` | 673.9 MB | only if a job that *opened* in 2025 appears new in the current API — rare |
| `current_jobs_2026` | 323.3 MB | **yes** |
| `historical_jobs_2026` | 9.3 MB | **yes** |
| everything else (14 files) | ~294 MB | no |
| **total** | **1.30 GB** | ~332 MB actually changes |

About **975 MB/day re-uploaded for nothing**. And this is the step that failed on 2026-08-08, dying in R2's `CompleteMultipartUpload` — the exact flake the `_CHUNK_SIZE` comment at `sync_to_r2.py:39-44` describes. Fewer, smaller uploads means fewer chances to hit it.

## What I found *didn't* need fixing

- **Rewrites are already scoped.** `collect_data.py` and `collect_current_data.py` both group by `positionOpenDate` year and only write the years they touched. The historical API is queried on `StartPositionOpenDate`/`EndPositionOpenDate`, so a 14-day window can only produce current-year rows (plus the prior year for ~2 weeks each January).
- **Downloads mostly can't shrink.** `prep_web_data.py` genuinely reads historical 2018+ and current 2024+. Only 2013–2017 is skippable, and that's 21 MB.

## How it works

```
sync_to_r2.py --snapshot       # records (size, mtime_ns) per parquet
sync_to_r2.py --only-changed   # skips files matching that baseline
```

The daily workflow snapshots immediately after the R2 download, before collection touches anything. Both flags are opt-in, so `repoll-status.yml` keeps its current upload-everything behavior.

## Fail-safe direction

Skipping a file that really changed would leave stale data in R2 **with no error**, so every uncertain path uploads instead:

- missing / unreadable / non-object baseline → warn, upload everything
- file absent from the baseline (January's new year file) → upload
- rewrite that preserved byte count → mtime still moves → upload

## Verification

- 8 new tests in `scripts/tests/test_sync_baseline.py`, weighted toward "must NOT skip" cases.
- End-to-end run of the real `main()` with the uploader stubbed: snapshot → rewrite 2 files → sync uploaded exactly `{web/jobs_5yr.parquet, web/static.json, data/historical_jobs_2026.parquet, data/current_jobs_2026.parquet}` and skipped the other three.
- Fail-safe path exercised: baseline deleted → all 5 data files uploaded.
- Pre-existing and unrelated: `test_collect.py` can't collect (no `pyarrow` in my local env) and 3 `test_agency_dedup` tests fail — both also fail on clean `main`. Passing count goes 13 → 21.

## Still open

The OOM that killed two runs (empty step conclusions) is untouched. That's `prep_web_data.py:164` doing `pd.read_parquet(path)` with no projection across 12 files, pulling in `MatchedObjectDescriptor` — 99% of those files' bytes. Note it can't simply be projected away: the grade block re-extracts `minimumGrade`/`maximumGrade`/`payScale` from that JSON for *every* row that has it, so dropping the column would silently change grades on the live site. Needs per-row-group extraction. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)