### PR TITLE
Skip the retry guard on the primary run

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -48,14 +48,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Guard for the retry crons. The expensive job downloads the whole dataset
-  # from R2 before it can tell whether there is anything to do, so decide here
-  # instead: if a run already succeeded today, the retries stop at this job.
+  # Guard for the RETRY crons only. The expensive job downloads the whole
+  # dataset from R2 before it can tell whether there is anything to do, so a
+  # retry decides here instead and stops if the day is already done.
   #
-  # This job is inside the same concurrency group as the real work, so a retry
-  # that fires while the primary run is still going waits for it to finish and
-  # then correctly sees the success — it does not race it.
+  # Deliberately skipped for the primary 07:37 run and for manual dispatches.
+  # A separate job means a separate runner acquisition, and on 2026-08-10 this
+  # job itself sat unallocated for over 15 minutes while the real work waited
+  # behind `needs`. Since the first run of the day never has a prior success to
+  # find, making it wait for a second runner is pure added latency on exactly
+  # the path this workflow is trying to protect. Retries can afford the wait.
+  #
+  # This job shares the concurrency group with the real work, so a retry that
+  # fires while the primary run is still going waits for it to finish and then
+  # correctly sees the success — it does not race it.
   check:
+    if: github.event_name == 'schedule' && github.event.schedule != '37 7 * * *'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -67,13 +75,6 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
       run: |
-        # A human asking for a run always gets one.
-        if [ "${{ github.event_name }}" != "schedule" ]; then
-          echo "Triggered by ${{ github.event_name }} — running."
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
         TODAY=$(date -u +%F)
         SUCCESSES=$(gh run list \
           --workflow=daily-data-update.yml \
@@ -92,7 +93,12 @@ jobs:
 
   update-data:
     needs: check
-    if: needs.check.outputs.should_run == 'true'
+    # `check` is skipped for the primary run and for dispatches, and a skipped
+    # dependency would normally skip this job too, hence the explicit result
+    # handling. Anything other than a clean "already done today" runs the work:
+    # a guard that errored tells us nothing, and missing a day's data is worse
+    # than a redundant run, which collection dedupes anyway.
+    if: ${{ !cancelled() && (needs.check.result != 'success' || needs.check.outputs.should_run == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 120  # 2 hour timeout for data update
     


### PR DESCRIPTION
Fixes a flaw I introduced in #519.

## What went wrong

The `check` job costs a **second runner acquisition**, and `update-data` waits behind it via `needs`. On a scarce-runner day — the exact scenario #519 exists for — that makes things worse, not better.

Demonstrated today: the run dispatched at 14:02 UTC had `check` sit **unallocated for over 18 minutes**. `update-data` was never created, because a dependent job isn't scheduled until its dependency finishes. A guard meant to make wasted runs cheap became the thing blocking the useful run.

## The fix

The first run of the day can never find a prior success, so the guard tells it nothing. Skip it for the primary `37 7 * * *` cron and for manual dispatches:

```yaml
check:
  if: github.event_name == 'schedule' && github.event.schedule != '37 7 * * *'
```

The daily critical path is back to **one** runner acquisition, as before #519. Only the 13:37 / 19:37 retries pay for a guard job — and a retry can afford the wait, it's already the fallback.

`update-data` now handles a skipped dependency explicitly, since a skipped `needs` would otherwise skip it:

```yaml
if: ${{ !cancelled() && (needs.check.result != 'success' || needs.check.outputs.should_run == 'true') }}
```

Fail-safe direction: anything other than a clean "already done today" runs the work. A guard that errored tells us nothing, and missing a day of data is worse than a redundant run, which collection dedupes.

## Verification

| trigger | check | update-data |
|---|---|---|
| schedule 37 7 (primary) | skipped | **runs** |
| schedule 37 13, day open | success, should_run=true | **runs** |
| schedule 37 13, day done | success, should_run=false | skipped |
| workflow_dispatch | skipped | **runs** |
| guard errored | failure | **runs** (fail-safe) |
| run cancelled | — | skipped |

Also asserted that the cron literal inside the guard's condition still equals the first entry in `on.schedule` — if those drift apart the guard silently attaches to the wrong run, which would be invisible. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)