### PR TITLE
Fetch the parquet once instead of range-reading it

### DIFF
--- a/web/shared/wasm-api.js
+++ b/web/shared/wasm-api.js
@@ -12,10 +12,19 @@
 // Deliberately plain functions taking an explicit `conn`. No client object, no
 // wrapper class, no patched global fetch — the call sites say what they fetch.
 //
-// IMPORTANT: query the parquet with read_parquet('https://…') in the SQL text.
-// db.registerFileURL() downloads the ENTIRE file up front (measured: one GET
-// 200 for all 51 MB) no matter what directIO says. Only the SQL path issues
-// Range requests. See memory/reference_duckdb_wasm_range_reads.md.
+// The parquet is fetched once in initDb() and queried from memory. This
+// REVERSES the previous rule ("query with read_parquet('https://…') so DuckDB
+// issues Range requests, because registerFile* downloads the whole file").
+// That rule's factual claim still holds -- registerFile* does pull all 48 MB
+// up front -- but the assumption that this is the expensive option did not
+// survive measurement:
+//
+//   cold range reads   ~9.4s between connection ready and first chart
+//   whole-file fetch    ~3.8s for all 48 MB, then queries run locally
+//
+// Range responses are also cached per byte-range, so each new filter that
+// touches new column chunks pays again, while one buffer serves every filter.
+// (The referenced memory/reference_duckdb_wasm_range_reads.md did not exist.)
 
 import * as duckdb from 'https://esm.sh/@duckdb/duckdb-wasm';
 
@@ -27,7 +36,22 @@ import {
 // Matches MAX_ROWS in the old api/download.py.
 export const DOWNLOAD_ROW_LIMIT = 100000;
 
-/** Boot DuckDB-WASM. Returns a connection; `src` is the SQL-ready table ref. */
+// Name DuckDB sees for the in-memory copy of the parquet.
+const LOCAL_PARQUET = 'jobs.parquet';
+
+/** Boot DuckDB-WASM. Returns a connection; `src` is the SQL-ready table ref.
+ *
+ *  The file is fetched once and handed to DuckDB as bytes, rather than left on
+ *  R2 for read_parquet() to range-read. The note this replaces was right that
+ *  registerFile* pulls the whole file up front; what changed is the measurement
+ *  of whether that is bad. Cold, the range-read path spent ~9.4s between having
+ *  a connection and the first chart, while the entire 48 MB downloads in ~3.8s.
+ *  Range responses also cache per byte-range, so a new filter touching new
+ *  column chunks pays again; one buffer is warm for every later filter.
+ *
+ *  Dropping httpfs is a side effect, not the point -- the extension is 0.42 MB
+ *  against a 34 MB (6.8 MB brotli) wasm bundle.
+ */
 export async function initDb(parquetUrl) {
   const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
   const workerUrl = URL.createObjectURL(
@@ -37,11 +61,18 @@ export async function initDb(parquetUrl) {
   await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
   URL.revokeObjectURL(workerUrl);
 
+  // Fetch and register in parallel with nothing else: callers already treat
+  // initDb() as the slow thing and never block first paint on it.
+  const resp = await fetch(parquetUrl);
+  if (!resp.ok) throw new Error(`parquet fetch failed: ${resp.status} ${resp.statusText}`);
+  const bytes = new Uint8Array(await resp.arrayBuffer());
+  await db.registerFileBuffer(LOCAL_PARQUET, bytes);
+
   const conn = await db.connect();
-  await conn.query('INSTALL httpfs; LOAD httpfs;');
-  conn.__src = `read_parquet('${parquetUrl}')`;
+  conn.__src = `read_parquet('${LOCAL_PARQUET}')`;
   return conn;
 }
+
 
 function src(conn) {
   if (!conn.__src) throw new Error('connection was not created by initDb()');


### PR DESCRIPTION
Follow-up to #523, which found the cause but deliberately didn't fix it. This is the fix.

Reverses the rule at the top of `wasm-api.js`. That rule's *factual* claim was correct — `registerFile*` pulls all 48 MB up front, only the SQL path issues Range requests. What didn't survive measurement is the assumption that the whole-file download is the expensive option.

## Cold A/B

Both variants served locally, each with its own cache-busted parquet URL so neither could reuse the other's bytes. (Browsers partition the HTTP cache by top-level site — which is why every "warm" number I took against production earlier was meaningless for localhost, and why this had to be measured this way.)

Chaplain filter, cold:

| | range reads (today) | fetch once |
|---|---|---|
| duckdb ready | 1,565ms | 4,486ms *(includes the 48 MB)* |
| first chart | 12,982ms | **4,963ms** |
| everything rendered | 13,053ms | **5,006ms** |
| connection → first result | 11,417ms | **477ms** |

**2.6x faster cold.** The connection→result collapse is the real story: cold Range requests against 2.96M rows cost ~11s, and since responses cache *per byte-range*, each new filter touching new column chunks pays again. One buffer serves every filter — a second filter with the file HTTP-cached finished in **1,430ms**, against 7–9s on the current site.

Dropping `httpfs` falls out of this but isn't the point: the extension is 0.42 MB against a 34 MB (6.8 MB brotli) wasm bundle.

## Verified identical, not just faster

- chaplain **2,737** rows and nurse **125,663** — both match the current site exactly.
- `poster.html` and `overlay-poster.html` share `initDb`; both still render (checked one live, 20 chart elements, no runtime error — the one "error" my scan flagged was a `<script>` tag containing the word in its source).
- `web/tests/test_filters.py` + `web/tests/test_pages_dist.py`: 57 passed.

## The tradeoff

48 MB up front on a cold visit. Those users wait ~13s today, so it's an improvement for them too — but it's a real change for metered connections, and worth a deliberate yes rather than my assuming it.

If that's a concern, the alternative is keeping range reads and accepting ~13s cold, since the intermediate options don't help: the extension is 1% of the boot, and query concurrency is already fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)