### PR TITLE
Make the repoll notice when it under-collects a date

### DIFF
--- a/.github/workflows/repoll-status.yml
+++ b/.github/workflows/repoll-status.yml
@@ -162,6 +162,36 @@ jobs:
         if-no-files-found: ignore
         retention-days: 90
 
+    - name: Check for pagination under-collection
+      if: always()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const alertFile = 'logs/PAGINATION_UNDER_COLLECTION.txt';
+          if (fs.existsSync(alertFile)) {
+            const content = fs.readFileSync(alertFile, 'utf8');
+            const today = new Date().toISOString().split('T')[0];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = '## Pagination Under-Collection (repoll)\n\n' +
+              '**The API reported more total jobs for a date than the repoll collected.** ' +
+              'Statuses for the rows we never saw are stale — they keep whatever status the ' +
+              'parquet already had, which is exactly what the repoll exists to correct.\n\n' +
+              '**Affected dates:**\n```\n' + content + '\n```\n\n' +
+              '**Action required:** Re-run the repoll for these dates. If it recurs, check ' +
+              'whether the API changed its continuationToken pagination.\n\n' +
+              `[View the workflow run](${runUrl})`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Pagination Under-Collection (repoll) - ' + today,
+              body,
+              labels: ['bug', 'data-issue'],
+              assignees: ['abigailhaddad'],
+            });
+            fs.unlinkSync(alertFile);
+          }
+
     - name: Check for pagination cap hits (500 / 10,000)
       if: always()
       uses: actions/github-script@v7

--- a/scripts/repoll_status.py
+++ b/scripts/repoll_status.py
@@ -56,9 +56,16 @@ def get_page(params: Optional[Dict] = None, next_url: Optional[str] = None, retr
                 resp = requests.get(f"{base_url}/api/historicjoa", params=params, timeout=120)
 
             if resp.status_code == 503:
-                wait = (attempt + 1) * 5
-                time.sleep(wait)
-                continue
+                if attempt < retries - 1:
+                    time.sleep((attempt + 1) * 5)
+                    continue
+                # The last 503 used to `continue` too, falling out of the loop
+                # and returning None. The caller's data.get(...) then died with
+                # "'NoneType' object has no attribute 'get'", which the worker
+                # swallowed into a per-date error string — so a sustained API
+                # outage read as a mystery AttributeError. Say what happened.
+                raise requests.HTTPError(
+                    f"503 Service Unavailable after {retries} attempts", response=resp)
 
             resp.raise_for_status()
 
@@ -74,17 +81,29 @@ def get_page(params: Optional[Dict] = None, next_url: Optional[str] = None, retr
             else:
                 raise
 
+    # Unreachable — every exit path above either returns or raises. Here so a
+    # future edit to the loop can never resurrect the silent `return None`.
+    raise requests.HTTPError(f"exhausted {retries} attempts with no response")
+
 
 def fetch_all_for_date(date_str: str) -> List[Dict]:
     """Fetch all jobs from the Historical API for a single date."""
     params = {"StartPositionOpenDate": date_str, "EndPositionOpenDate": date_str}
     all_jobs = []
     next_url = None
+    page_num = 1
+    expected_total = None
 
     while True:
         data = get_page(params=params, next_url=next_url)
         jobs = data.get("data", [])
         all_jobs.extend(jobs)
+
+        # The API tells us up front how many rows this date has. Reading it is
+        # the difference between catching under-collection and guessing at it
+        # from a suspicious round number.
+        if page_num == 1:
+            expected_total = data.get("paging", {}).get("metadata", {}).get("totalCount")
 
         next_path = data.get("paging", {}).get("next")
         if next_path and next_path.strip():
@@ -93,12 +112,29 @@ def fetch_all_for_date(date_str: str) -> List[Dict]:
             else:
                 next_url = f"https://data.usajobs.gov{next_path}"
             params = None
+            page_num += 1
         else:
             break
 
+    under_collected = expected_total is not None and len(all_jobs) < expected_total
+    if under_collected:
+        msg = (f"🚨 PAGINATION UNDER-COLLECTION: repoll date {date_str} — API reported "
+               f"{expected_total} total jobs but only collected {len(all_jobs)} after "
+               f"{page_num} page(s). Statuses for the rows we never saw are stale.")
+        log(msg)
+        log_dir = os.path.join(os.path.dirname(__file__), '..', 'logs')
+        os.makedirs(log_dir, exist_ok=True)
+        with open(os.path.join(log_dir, 'PAGINATION_UNDER_COLLECTION.txt'), 'a') as f:
+            f.write(f"repoll date {date_str}: expected {expected_total}, "
+                    f"got {len(all_jobs)} ({page_num} pages)\n")
+
     # Cap tripwire: a single date returning exactly 500 (page size) or 10,000
     # may mean pagination silently stopped instead of reaching the true end.
-    check_cap(len(all_jobs), f"repoll date {date_str}")
+    # Skipped when the count already came up short — the tripwire is for
+    # truncation that is otherwise *silent*, and firing both just opens two
+    # issues about one event (see #531/#532 on the daily collection).
+    if not under_collected:
+        check_cap(len(all_jobs), f"repoll date {date_str}")
 
     return all_jobs
 


### PR DESCRIPTION
Follow-up to #534. I said the repoll would "double-alert on the next 503" — that was wrong. It has no under-collection alert to double up with, which turns out to be the actual problem. Two real defects instead:

## 1. `get_page` returned `None` on a sustained 503

```python
if resp.status_code == 503:
    wait = (attempt + 1) * 5
    time.sleep(wait)
    continue          # <- the LAST attempt does this too
```

The final attempt hit `continue`, the loop ended, and the function fell off the bottom returning `None`. The caller's `data.get("data", [])` then raised `'NoneType' object has no attribute 'get'`, which `fetch_date_worker` swallowed into a per-date error string. So the exact API outage that truncated 2026-08-07 in the daily collection would surface here as a mystery `AttributeError` — and only if `errors > 5` did anything warn at all.

Now raises `requests.HTTPError("503 Service Unavailable after N attempts")`, plus an unreachable raise after the loop so a future edit can't resurrect the silent `None`.

## 2. Under-collection was completely invisible

`fetch_all_for_date` never read `paging.metadata.totalCount`. The cap tripwire was the only guard, and it fires only on *exactly* 500 or 10,000 — a date that returned 900 of 1196 rows was accepted silently, and the stale statuses it exists to correct stayed stale.

It now compares against `totalCount` and writes `logs/PAGINATION_UNDER_COLLECTION.txt`. The repoll workflow had no step for that file (the daily workflow has had one all along), so this adds one.

And the cap tripwire is skipped when the count already came up short, matching #534 — one truncation, one issue.

## Testing

Stubbed `requests.get` / `get_page`:

| case | result |
|---|---|
| every attempt 503s | `get_page` raises `503 Service Unavailable after 3 attempts`; worker error string contains no `NoneType` |
| 500 rows, `totalCount: 1196`, API drops the tail | under-collection alert names the date, cap alert empty |
| clean 500-row date, `totalCount: 500` | cap tripwire still fires — the silent case it's for |
| normal 622-row date over two pages | no alerts |

Not covered: the parallel path. 15 worker threads can append to `PAGINATION_UNDER_COLLECTION.txt` at once; single small `write` calls to an O_APPEND handle won't interleave in practice, but I didn't test it under contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)