### PR TITLE
Stop writing a second copy of a job instead of updating it

### DIFF
--- a/scripts/collect_data.py
+++ b/scripts/collect_data.py
@@ -354,6 +354,38 @@ def load_existing_jobs(parquet_path: str) -> set:
         return set()
 
 
+def _control_numbers(df: pd.DataFrame) -> pd.Series:
+    """One control-number-per-row Series, preferring the snake_case column.
+
+    These files carry the same id under two names: `usajobsControlNumber` (from
+    the API) and `usajobs_control_number` (added later). Rows written before
+    that second column existed have it as NaN, and the old lookup here was
+
+        row.get('usajobs_control_number', row.get('usajobsControlNumber', ''))
+
+    which only falls back when the KEY is missing. Once the column exists every
+    row has the key, so those older rows resolved to NaN -> "nan", never matched
+    the overlap set, survived the "remove the rows we are replacing" mask, and
+    were then concatenated alongside their own replacement. That produced 2,124
+    duplicate pairs in 2025 and 698 in 2026, every one of them a NULL-snake-col
+    row twinned with a populated one. Coalesce properly instead.
+    """
+    def as_text(vals):
+        # A numeric column that contains any null is read back as float64, and
+        # astype(str) would then render 861001500 as "861001500.0" — which
+        # matches nothing on the other side of the comparison.
+        if pd.api.types.is_integer_dtype(vals) or pd.api.types.is_float_dtype(vals):
+            return vals.astype('Int64').astype(str)
+        return vals.astype(str)
+
+    out = pd.Series('', index=df.index, dtype=object)
+    for col in ('usajobsControlNumber', 'usajobs_control_number'):
+        if col in df.columns:
+            vals = df[col]
+            out = out.mask((out == '') & vals.notna(), as_text(vals))
+    return out
+
+
 def save_jobs_to_parquet(jobs: List[Dict], parquet_path: str):
     """Save jobs to parquet file, merging with existing data.
     
@@ -400,46 +432,50 @@ def save_jobs_to_parquet(jobs: List[Dict], parquet_path: str):
         if 'usajobsControlNumber' in existing_df.columns and 'usajobs_control_number' not in existing_df.columns:
             existing_df['usajobs_control_number'] = existing_df['usajobsControlNumber'].astype(str)
         
-        # Get control numbers from both dataframes
-        existing_control_numbers = set()
-        if 'usajobs_control_number' in existing_df.columns:
-            existing_control_numbers.update(existing_df['usajobs_control_number'].dropna().astype(str))
-        if 'usajobsControlNumber' in existing_df.columns:
-            existing_control_numbers.update(existing_df['usajobsControlNumber'].dropna().astype(str))
-            
-        new_control_numbers = set()
-        if 'usajobs_control_number' in new_df.columns:
-            new_control_numbers.update(new_df['usajobs_control_number'].dropna().astype(str))
-        if 'usajobsControlNumber' in new_df.columns:
-            new_control_numbers.update(new_df['usajobsControlNumber'].dropna().astype(str))
+        # Get control numbers from both dataframes. Both sides go through the
+        # same coalesce so a row is identified identically wherever it is read.
+        existing_control_numbers = set(_control_numbers(existing_df)) - {''}
+        new_control_numbers = set(_control_numbers(new_df)) - {''}
         
         # Identify which jobs to update (exist in both)
         overlapping_control_numbers = existing_control_numbers.intersection(new_control_numbers)
-        
+
         # Update last_seen for existing jobs that we're updating
         if overlapping_control_numbers and 'last_seen' not in existing_df.columns:
             existing_df['last_seen'] = existing_df.get('inserted_at', datetime.now().isoformat())
-        
+
         # Remove duplicates from existing data (keep existing version for now)
         # We'll add the new versions below
         if overlapping_control_numbers:
             # Create mask for jobs to keep (not in overlap)
-            mask = ~existing_df.apply(lambda row: 
-                str(row.get('usajobs_control_number', row.get('usajobsControlNumber', ''))) in overlapping_control_numbers, 
-                axis=1)
+            mask = ~_control_numbers(existing_df).isin(overlapping_control_numbers)
             existing_df = existing_df[mask]
-        
+
         # Combine dataframes - this adds new jobs and updated versions of existing jobs
         combined_df = pd.concat([existing_df, new_df], ignore_index=True)
-        
-        # Verify we haven't lost any jobs
-        final_count = len(combined_df)
-        if final_count < initial_count:
-            raise ValueError(f"DATA LOSS PREVENTED: Would have lost {initial_count - final_count} jobs. "
-                           f"Initial: {initial_count}, Final: {final_count}")
-        
-        print(f"    📊 {parquet_path}: {initial_count} → {final_count} jobs "
-              f"(+{final_count - initial_count} new/updated)")
+
+        # Belt and braces: collapse any control number that still appears twice,
+        # keeping the newest copy. This heals files that already carry duplicate
+        # pairs from the bug described on _control_numbers() — they are only
+        # fixed when something rewrites the file, which is here.
+        before_dedupe = len(combined_df)
+        keys = _control_numbers(combined_df)
+        combined_df = combined_df[~keys.duplicated(keep='last') | (keys == '')]
+        if len(combined_df) < before_dedupe:
+            print(f"    🧹 Collapsed {before_dedupe - len(combined_df)} duplicate row(s) "
+                  f"in {parquet_path}")
+
+        # Verify we haven't lost any actual jobs. Compare DISTINCT control
+        # numbers, not row counts — with the dedupe above, a shrinking row count
+        # is the fix working, while a shrinking job count is real loss.
+        initial_jobs = len(existing_control_numbers)
+        final_jobs = len(set(_control_numbers(combined_df)) - {''})
+        if final_jobs < initial_jobs:
+            raise ValueError(f"DATA LOSS PREVENTED: Would have lost {initial_jobs - final_jobs} jobs. "
+                           f"Initial: {initial_jobs}, Final: {final_jobs}")
+
+        print(f"    📊 {parquet_path}: {initial_jobs} → {final_jobs} jobs "
+              f"(+{final_jobs - initial_jobs} new/updated)")
     else:
         combined_df = new_df
         print(f"    📊 Created {parquet_path} with {len(combined_df)} jobs")

--- a/update/test_data_integrity.py
+++ b/update/test_data_integrity.py
@@ -100,6 +100,106 @@ def check_data_recency(filepath, max_days_old, description):
         print(f"{Colors.RED}❌ FAIL{Colors.RESET} {description} - Error checking dates: {e}")
         return False
 
+ID_COLUMNS = ('usajobsControlNumber', 'usajobs_control_number', 'PositionID')
+
+
+def _job_ids(filepath):
+    """Distinct job ids in a parquet, or None if it has no recognisable id column.
+
+    Coalesces the two spellings the historical files carry: rows written before
+    `usajobs_control_number` existed have it as NULL while `usajobsControlNumber`
+    is set, so reading either column alone under-counts.
+    """
+    names = pq.ParquetFile(filepath).schema.names
+    cols = [c for c in ID_COLUMNS if c in names]
+    if not cols:
+        return None
+
+    df = pd.read_parquet(filepath, columns=cols)
+    ids = pd.Series('', index=df.index, dtype=object)
+    for col in cols:
+        vals = df[col]
+        if pd.api.types.is_integer_dtype(vals) or pd.api.types.is_float_dtype(vals):
+            text = vals.astype('Int64').astype(str)
+        else:
+            text = vals.astype(str)
+        ids = ids.mask((ids == '') & vals.notna(), text)
+    return set(ids) - {''}
+
+
+def _distinct_job_count(filepath):
+    ids = _job_ids(filepath)
+    return None if ids is None else len(ids)
+
+
+def check_no_duplicate_control_numbers():
+    """Fail if a parquet gained duplicate control numbers since the baseline.
+
+    One job should be one row. Duplicates arrived through a merge bug in
+    save_jobs_to_parquet (see _control_numbers there) that left 2,124 duplicate
+    pairs in 2025 and 698 in 2026 — each a row whose `usajobs_control_number`
+    was NULL, twinned with its own replacement.
+
+    This is a ratchet, not a clean-room assertion: the write path now collapses
+    duplicates whenever it rewrites a file, but a file is only rewritten when a
+    date inside it is collected, so the known ones clear out gradually. The
+    recorded allowance therefore only ever moves down — any INCREASE fails.
+    """
+    baseline_file = 'data_baseline.json'
+    if not os.path.exists(baseline_file):
+        print(f"{Colors.YELLOW}⚠️  No baseline yet — skipping duplicate check{Colors.RESET}")
+        return True
+
+    with open(baseline_file, 'r') as f:
+        baseline = json.load(f)
+
+    allowance = baseline.get('duplicate_counts')
+    recording = allowance is None
+    if recording:
+        allowance = {}
+        print(f"{Colors.YELLOW}⚠️  Recording first duplicate-count baseline{Colors.RESET}")
+
+    all_good = True
+    updated = {}
+
+    for filename in sorted(os.listdir('../data')):
+        if not filename.endswith('.parquet'):
+            continue
+        filepath = os.path.join('../data', filename)
+        try:
+            ids = _job_ids(filepath)
+            if ids is None:
+                continue
+            rows = pq.ParquetFile(filepath).metadata.num_rows
+            dupes = rows - len(ids)
+        except Exception as e:
+            print(f"{Colors.YELLOW}⚠️  WARN{Colors.RESET} Could not check {filename}: {e}")
+            continue
+
+        # On the recording run every file sets its own allowance, so nothing
+        # fails — this is establishing where the ratchet starts, not judging it.
+        allowed = dupes if recording else allowance.get(filename, 0)
+        updated[filename] = dupes if recording else min(dupes, allowed)
+
+        if dupes > allowed:
+            print(f"{Colors.RED}❌ FAIL{Colors.RESET} {filename} gained duplicates: "
+                  f"{allowed} allowed → {dupes} present ({rows:,} rows, {len(ids):,} jobs)")
+            all_good = False
+        elif dupes > 0:
+            print(f"{Colors.YELLOW}⚠️  WARN{Colors.RESET} {filename} still carries {dupes:,} "
+                  f"known duplicate row(s) — clears when the file is next rewritten")
+        else:
+            print(f"{Colors.GREEN}✅ PASS{Colors.RESET} {filename} one row per job ({len(ids):,})")
+
+    # Ratchet: never let the allowance grow, and bank any improvement.
+    if updated != allowance:
+        baseline['duplicate_counts'] = updated
+        with open(baseline_file, 'w') as f:
+            json.dump(baseline, f, indent=2)
+
+    return all_good
+
+
 def check_no_data_loss():
     """Ensure historical data hasn't been lost"""
     baseline_file = 'data_baseline.json'  # Store in update directory
@@ -117,12 +217,21 @@ def check_no_data_loss():
 
     all_good = True
 
-    # Check each parquet file hasn't shrunk
+    # Check each parquet file hasn't shrunk.
+    #
+    # NB: create_baseline() stores len(unique ids) under the name "row_counts",
+    # so this must count DISTINCT ids too. Comparing it against
+    # metadata.num_rows (as this did) compares jobs to rows, and the two differ
+    # whenever a file carries duplicates: historical_jobs_2026 held 159,854
+    # distinct ids in 160,552 rows, so the check reported a comfortable "grew"
+    # and would have kept doing so while up to 698 real jobs went missing.
     for filename, baseline_count in baseline.get('row_counts', {}).items():
         filepath = f"../data/{filename}"
         if os.path.exists(filepath):
             try:
-                current_count = pq.ParquetFile(filepath).metadata.num_rows
+                current_count = _distinct_job_count(filepath)
+                if current_count is None:
+                    current_count = pq.ParquetFile(filepath).metadata.num_rows
 
                 if current_count < baseline_count:
                     print(f"{Colors.RED}❌ FAIL{Colors.RESET} {filename} shrunk: {baseline_count} → {current_count}")
@@ -221,9 +330,20 @@ def create_baseline(filepath):
     The no-data-loss check uses row counts; the no-job-ID-loss check uses a
     small sentinel sample so we can detect corruption without a 70 MB JSON.
     """
+    # The duplicate allowance is a ratchet — carry the old one forward so a
+    # rewrite here can never hand back headroom the data no longer needs.
+    prior_dupes = {}
+    if os.path.exists(filepath):
+        try:
+            with open(filepath) as f:
+                prior_dupes = json.load(f).get('duplicate_counts', {}) or {}
+        except Exception:
+            pass
+
     baseline = {
         'created_at': datetime.now().isoformat(),
         'row_counts': {},
+        'duplicate_counts': {},
         'job_ids': {}  # Sentinel sample only — first 500 IDs per file
     }
 
@@ -231,23 +351,20 @@ def create_baseline(filepath):
     for filename in os.listdir(data_dir):
         if filename.endswith('.parquet'):
             try:
-                # Read only the ID column to avoid loading full parquet
                 path = os.path.join(data_dir, filename)
-                id_col = None
-                for col in ('usajobsControlNumber', 'usajobs_control_number', 'PositionID'):
-                    try:
-                        s = pd.read_parquet(path, columns=[col])[col]
-                        id_col = col
-                        ids = sorted(s.dropna().astype(str).unique())
-                        baseline['row_counts'][filename] = len(ids)
-                        baseline['job_ids'][filename] = ids[:500]  # sentinel sample
-                        break
-                    except Exception:
-                        continue
+                ids = _job_ids(path)  # coalesces both id spellings
 
-                if id_col is None:
+                if ids is None:
                     df = pd.read_parquet(path)
                     baseline['row_counts'][filename] = len(df)
+                    continue
+
+                baseline['row_counts'][filename] = len(ids)
+                baseline['job_ids'][filename] = sorted(ids)[:500]  # sentinel sample
+
+                dupes = pq.ParquetFile(path).metadata.num_rows - len(ids)
+                baseline['duplicate_counts'][filename] = min(
+                    dupes, prior_dupes.get(filename, dupes))
 
             except Exception as e:
                 print(f"Could not read {filename}: {e}")
@@ -427,6 +544,11 @@ def run_tests():
     # Test 7: Historical monthly coverage (catches collection gaps)
     print_header("7. HISTORICAL MONTHLY COVERAGE")
     if not check_historical_monthly_coverage():
+        all_passed = False
+
+    # Test 8: One row per job
+    print_header("8. NO DUPLICATE CONTROL NUMBERS")
+    if not check_no_duplicate_control_numbers():
         all_passed = False
 
     # Summary


### PR DESCRIPTION
Found while auditing whether the archive is missing data. It isn't losing jobs — it's storing some of them twice.

## The bug

`save_jobs_to_parquet` decided which existing rows to replace with:

```python
row.get('usajobs_control_number', row.get('usajobsControlNumber', ''))
```

`dict.get` falls back only when the **key** is missing, never when the **value** is NULL. These files carry the same id under both spellings, and rows written before the snake_case column existed have it as NULL. Those rows therefore resolved to `"nan"`, never matched the overlap set, survived the mask that removes the rows being replaced — and were then concatenated alongside their own replacement.

## The fingerprint matches exactly

| year | rows | distinct jobs | duplicate rows |
|---|---|---|---|
| 2025 | 169,145 | 167,021 | **2,124** |
| 2026 | 160,552 | 159,854 | **698** |

And splitting those duplicated groups by whether the snake_case column is populated:

```
2025:  snake col set 2124   |  snake col NULL 2124
2026:  snake col set  698   |  snake col NULL  698
```

Every duplicate is one NULL-snake-col row twinned with a populated one. 2024 and earlier have zero duplicates.

The published site is unaffected — `prep_web_data.py` already does `drop_duplicates(subset=["usajobsControlNumber"], keep="last")`. This is the raw archive only.

## Changes

`_control_numbers()` coalesces the two spellings (and normalises the numeric column so a nullable int doesn't stringify as `"861001500.0"`). Both sides of the comparison use it. The merge then collapses any control number still appearing twice, keeping the newest copy, so **files heal as they are rewritten**.

The `DATA LOSS PREVENTED` guard now compares distinct jobs rather than rows — with dedup in place a smaller row count is the repair working, and the old row-count guard would have blocked it.

## Test changes

**New check 8** fails if a file *gains* duplicates. Deliberately a ratchet, not a clean-room assertion: the known duplicates only clear when their file is next rewritten, and 2025 is rarely touched, so a hard assertion would block the nightly sync indefinitely. The allowance records once, never grows, and tightens whenever a file is repaired.

**`check_no_data_loss` was comparing jobs against rows.** `create_baseline` stores `len(unique ids)` under the key `row_counts`, and the check compared that to `metadata.num_rows`. For 2026 that is 159,854 vs 160,552 — it reported a comfortable `✅ PASS grew` and would have kept doing so while up to 698 real jobs quietly disappeared. Both sides now count distinct ids, coalescing both spellings.

## Testing

End-to-end on a fixture carrying the live shape (duplicate pair, one copy NULL-snake-col): re-saving the job collapses it to one row, the untouched neighbour survives, no data loss, and the guard does not false-trip on an ordinary update.

Ratchet, five scenarios: records on first run without failing → holds steady with a WARN → **fails** when a new duplicate appears → tightens to 0 when a file is healed → **fails** if a healed file regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)