### PR TITLE
Dedup the retry job's fallback issue

### DIFF
--- a/.github/workflows/notify-on-pipeline-failure.yml
+++ b/.github/workflows/notify-on-pipeline-failure.yml
@@ -45,14 +45,39 @@ jobs:
               // issue now instead of waiting for an attempt 2 that won't come.
               console.log(`Rerun request failed: ${e.message} — opening issue instead.`);
               const date = new Date().toISOString().split('T')[0];
-              await github.rest.issues.create({
+              const title = `${run.name} Failed - ${date}`;
+
+              // Dedup exactly as the notify job does. When the runner survives
+              // its failure, the watched workflow's own "Check for failures"
+              // step has already opened this issue under this title, and this
+              // path opens a second one seconds later — which is what happened
+              // on 2026-08-17 (#542 and #543, one event).
+              const existing = await github.paginate(github.rest.issues.listForRepo, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `${run.name} Failed - ${date}`,
-                body: `**${run.name}** failed and the automatic rerun could not be started (${e.message}).\n\n[View the failed run](${run.html_url})`,
-                labels: ['bug', 'automated', 'pipeline-failure'],
-                assignees: ['abigailhaddad'],
+                state: 'open',
+                per_page: 100,
               });
+              const dupe = existing.find(i => i.title === title);
+
+              if (dupe) {
+                console.log(`Issue #${dupe.number} already open for "${title}" — commenting instead.`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: dupe.number,
+                  body: `The automatic rerun could not be started either (${e.message}), so this run will not retry itself.\n\n[View the failed run](${run.html_url})`,
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body: `**${run.name}** failed and the automatic rerun could not be started (${e.message}).\n\n[View the failed run](${run.html_url})`,
+                  labels: ['bug', 'automated', 'pipeline-failure'],
+                  assignees: ['abigailhaddad'],
+                });
+              }
             }
 
   notify:


### PR DESCRIPTION
Caught by #504's own first live outing this afternoon.

Run 32039106067 failed at `Auto-merge PR if tests pass` — GitHub returned a 503 to `gh pr merge`. The retry workflow then tried to rerun the failed jobs and **hit a 503 of its own**, so the fallback path fired exactly as designed and opened an issue immediately rather than waiting for an attempt 2 that would never arrive. That part worked.

The problem is it opened a *second* issue. When the runner survives its failure — as here, where only the final merge call failed — the watched workflow's own `Check for failures` step has already opened an issue under the same title. Result: #542 (in-job) and #543 (this fallback), 22 seconds apart, one event.

The `notify` job has always deduped by title. This path didn't. It now does, and comments on the existing issue instead — which is worth having, because "the automatic rerun could not be started either, so this run will not retry itself" is precisely the thing the in-job issue cannot know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)