### PR TITLE
Retry the PR API calls instead of failing the whole run

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -430,16 +430,45 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.PAT_TOKEN }}
       run: |
-        # Check if PR already exists
-        PR_EXISTS=$(gh pr list --base main --head data-updates --state open --json number --jq length)
-        
+        # Every call here can come back 503 — GitHub threw them at everything on
+        # 2026-08-17. Untreated, a 503 on the lookup reads as "no PR exists" and
+        # a 503 on the create fails the step, both AFTER the data has already
+        # synced to R2, so the run goes red over a repo-side bookkeeping call.
+        LOOKUP_OK=false
+        for attempt in 1 2 3 4 5; do
+          if PR_EXISTS=$(gh pr list --base main --head data-updates --state open --json number --jq length 2>&1); then
+            LOOKUP_OK=true
+            break
+          fi
+          echo "  PR lookup failed (attempt $attempt/5): $PR_EXISTS"
+          sleep $((attempt * 10))
+        done
+
+        if [ "$LOOKUP_OK" != "true" ]; then
+          echo "::error::Could not reach GitHub to check for an existing PR after 5 attempts"
+          exit 1
+        fi
+
         if [ "$PR_EXISTS" -eq "0" ]; then
           echo "Creating new PR..."
-          gh pr create \
-            --base main \
-            --head data-updates \
-            --title "Daily data update - $(date +'%Y-%m-%d')" \
-            --body "Automated daily data update from USAJobs API"
+          for attempt in 1 2 3 4 5; do
+            if gh pr create \
+                 --base main \
+                 --head data-updates \
+                 --title "Daily data update - $(date +'%Y-%m-%d')" \
+                 --body "Automated daily data update from USAJobs API"; then
+              exit 0
+            fi
+            # It may have been created despite the error response.
+            if [ "$(gh pr list --base main --head data-updates --state open --json number --jq length 2>/dev/null)" = "1" ]; then
+              echo "PR exists despite the API error — continuing"
+              exit 0
+            fi
+            echo "  PR create failed (attempt $attempt/5) — retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::Could not create the data-updates PR after 5 attempts"
+          exit 1
         else
           echo "PR already exists, skipping creation"
         fi
@@ -450,24 +479,50 @@ jobs:
         # Wait a moment for PR to be created
         sleep 10
 
-        # Find the PR number
-        PR_NUMBER=$(gh pr list --base main --head data-updates --json number --jq '.[0].number')
+        # Find the PR number. Separate "GitHub would not answer" from "there is
+        # no PR" — the old single call conflated them, so a 503 here silently
+        # skipped the merge and passed the step.
+        LOOKUP_OK=false
+        for attempt in 1 2 3 4 5; do
+          if PR_NUMBER=$(gh pr list --base main --head data-updates --json number --jq '.[0].number' 2>&1); then
+            LOOKUP_OK=true
+            break
+          fi
+          echo "  PR lookup failed (attempt $attempt/5): $PR_NUMBER"
+          sleep $((attempt * 10))
+        done
 
-        if [ -n "$PR_NUMBER" ]; then
-          echo "Auto-merging PR #$PR_NUMBER"
-          gh pr merge $PR_NUMBER --merge --auto || {
-            # Tolerate transient API errors (502, stream cancel, etc.)
-            # The merge may have gone through despite the error response
-            sleep 5
-            PR_STATE=$(gh pr view $PR_NUMBER --json state --jq '.state')
-            if [ "$PR_STATE" = "MERGED" ]; then
-              echo "PR #$PR_NUMBER is already merged despite API error — continuing"
-            else
-              echo "PR #$PR_NUMBER merge failed (state: $PR_STATE)"
-              exit 1
-            fi
-          }
+        if [ "$LOOKUP_OK" != "true" ]; then
+          echo "::error::Could not reach GitHub to look up the data-updates PR after 5 attempts"
+          exit 1
         fi
+
+        if [ -z "$PR_NUMBER" ]; then
+          echo "No open data-updates PR — nothing to merge"
+          exit 0
+        fi
+
+        # Retry the merge itself. On 2026-08-17 a single 503 here failed a run
+        # whose data had already collected, tested and synced — and the retry
+        # workflow then re-ran the whole ~15 minute job to redo a 5 second call.
+        echo "Auto-merging PR #$PR_NUMBER"
+        for attempt in 1 2 3 4 5; do
+          if gh pr merge "$PR_NUMBER" --merge --auto; then
+            echo "Merge requested for PR #$PR_NUMBER"
+            exit 0
+          fi
+          # It may have gone through despite the error response.
+          PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo UNKNOWN)
+          if [ "$PR_STATE" = "MERGED" ]; then
+            echo "PR #$PR_NUMBER is already merged despite the API error — continuing"
+            exit 0
+          fi
+          echo "  merge attempt $attempt/5 failed (state: $PR_STATE) — retrying in $((attempt * 15))s"
+          sleep $((attempt * 15))
+        done
+
+        echo "::error::PR #$PR_NUMBER could not be merged after 5 attempts"
+        exit 1
       env:
         GH_TOKEN: ${{ secrets.PAT_TOKEN }}
 


### PR DESCRIPTION
Follow-up to today's red run, and cheaper than the alternative.

Run 32039106067 collected 2025-11-18, passed the integrity tests and **completed the R2 sync** — then went red because GitHub returned a single 503 to `gh pr merge`. The data was already safe. Only a repo-side bookkeeping call had failed.

The retry workflow from #504 then did what it is supposed to do and queued a rerun of the **entire ~15 minute job** to redo a five second API call. (Its rerun request 503'd too, so it never actually ran.) Retrying the call in place is the proportionate fix.

## Changes

Both PR steps retry with backoff — 5 attempts, 15s/30s/45s/60s for the merge, 10s-scaled for lookups — and both keep the existing "it may have gone through despite the error response" check.

They also now **distinguish "GitHub would not answer" from "there is no PR"**, which was a separate latent bug:

```bash
PR_NUMBER=$(gh pr list ... --jq '.[0].number')   # 503 -> empty string
if [ -n "$PR_NUMBER" ]; then ... fi              # -> silently skips the merge, step passes
```

A 503 on that lookup produced an empty PR number, which read as "nothing to merge" and passed the step having done nothing. Same shape in the create step, where a 503 on the existence check read as "no PR exists".

## Testing

Extracted both step bodies and ran them against a stubbed `gh`, nine scenarios:

| scenario | expected | result |
|---|---|---|
| merge succeeds first try | pass | ✓ |
| merge 503s twice, then succeeds | pass — **today's failure, survived** | ✓ |
| merge 503s forever | fail after 5 | ✓ |
| merge errors but PR is MERGED | pass | ✓ |
| lookup 503s forever | **fail loudly**, not skip | ✓ |
| no PR exists | pass, nothing to merge | ✓ |
| PR already exists | skip creation | ✓ |
| create 503s twice, then succeeds | pass | ✓ |
| create 503s forever | fail after 5 | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)