### PR TITLE
Publish announcement text to HuggingFace daily

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -375,6 +375,48 @@ jobs:
         cd update
         python test_data_integrity.py
 
+    # Publish announcement text to HuggingFace. The USAJOBS API is a poor source
+    # for it: Search only lists open jobs, so postings that open and close
+    # between runs are never captured, and MatchedObjectDescriptor drops content
+    # the announcement page shows. This scrapes the page instead, reading
+    # data/historical_jobs_2026.parquet off disk — the copy this run just
+    # refreshed — so it needs no R2 credentials of its own.
+    # See https://github.com/abigailhaddad/joa
+
+    - name: Check usajobs.gov is reachable from this runner
+      run: |
+        pip install beautifulsoup4 requests
+        python3 - <<'EOF'
+        import re, sys, requests
+        from bs4 import BeautifulSoup
+        UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+              "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+        r = requests.get("https://www.usajobs.gov/job/855359900",
+                         headers={"User-Agent": UA}, timeout=45)
+        soup = BeautifulSoup(r.text, "html.parser")
+        for t in soup(["script", "style", "noscript"]):
+            t.decompose()
+        text = re.sub(r"\s+", " ", soup.get_text(" ")).strip()
+        print(f"status {r.status_code}, {len(text):,} chars")
+        if not r.ok or len(text) < 5000:
+            sys.exit("usajobs.gov is not serving this runner. Move the scrape off "
+                     "GitHub Actions, or route it through a proxy.")
+        EOF
+
+    - name: Scrape new announcements and push to HuggingFace
+      env:
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      run: |
+        git clone --depth 1 https://github.com/abigailhaddad/joa.git /tmp/joa
+        pip install -r /tmp/joa/requirements.txt
+        ln -s "$GITHUB_WORKSPACE/data" /tmp/joa/data
+        cd /tmp/joa
+        # Metadata keeps changing after a posting appears, so rewrite every
+        # month once a month; the daily run only refreshes what it touched.
+        REFRESH=""
+        [ "$(date -u +%d)" = "01" ] && REFRESH="--refresh-all"
+        python3 update_daily.py $REFRESH
+
     - name: Commit and push to data-updates branch
       # Only runs if tests pass
       run: |


### PR DESCRIPTION
Adds two steps to `daily-data-update.yml`, after the integrity tests: a reachability check, then a scrape-and-push.

## Why

The USAJOBS API is a poor source for announcement text, in two ways.

Search only lists jobs open right now, so anything that opens and closes between collection runs is never captured. Measured against the Historical API, that's **5,274 of 2026's 162,030 postings**, and it isn't spread evenly — OPM has text for 159 of its 724.

For postings the API does return, `MatchedObjectDescriptor` drops content the page shows. There are confirmed cases where the page says a phrase and the API record doesn't.

Searching for "Rule of Many" finds 502 announcements in the API text and **659** in the scraped pages — a 31% undercount that hides whole agencies.

Neither gap can be backfilled from the API afterward. usajobs.gov serves closed announcements indefinitely, so the page is the source.

## How it fits

Reads `data/historical_jobs_2026.parquet` off disk — the copy this run just refreshed — so no R2 credentials here and no second fetch. Touches no parquet files, so it stays out of the commit and PR. About 800 new postings a day, roughly 40 seconds of scraping.

`--refresh-all` on the first of the month re-joins metadata across every month, since close dates and opening status keep changing after a posting appears.

## The one unknown

usajobs.gov sits behind Akamai and 403s anything that doesn't look like a browser. Whether it also objects to GitHub runner IPs can't be tested from a laptop, so the reachability check runs first and fails in about ten seconds with a clear message. If it does fail, `update_daily.py` runs unchanged from a cron on a laptop against the public R2 URL.

## Needs

`HF_TOKEN` repo secret — already added, write scope.

Code: https://github.com/abigailhaddad/joa
Dataset: https://huggingface.co/datasets/abigailhaddad/usajobs-scraping

🤖 Generated with [Claude Code](https://claude.com/claude-code)