### PR TITLE
Announcement text: all 53 fields to HuggingFace, plus duty stations from the page

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -450,47 +450,31 @@ jobs:
         cd update
         python test_data_integrity.py
 
-    # Publish announcement text to HuggingFace. The USAJOBS API is a poor source
-    # for it: Search only lists open jobs, so postings that open and close
-    # between runs are never captured, and MatchedObjectDescriptor drops content
-    # the announcement page shows. This scrapes the page instead, reading
-    # data/historical_jobs_2026.parquet off disk — the copy this run just
-    # refreshed — so it needs no R2 credentials of its own.
-    # See https://github.com/abigailhaddad/joa
-
-    - name: Check usajobs.gov is reachable from this runner
-      run: |
-        pip install beautifulsoup4 requests
-        python3 - <<'EOF'
-        import re, sys, requests
-        from bs4 import BeautifulSoup
-        UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-              "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
-        r = requests.get("https://www.usajobs.gov/job/855359900",
-                         headers={"User-Agent": UA}, timeout=45)
-        soup = BeautifulSoup(r.text, "html.parser")
-        for t in soup(["script", "style", "noscript"]):
-            t.decompose()
-        text = re.sub(r"\s+", " ", soup.get_text(" ")).strip()
-        print(f"status {r.status_code}, {len(text):,} chars")
-        if not r.ok or len(text) < 5000:
-            sys.exit("usajobs.gov is not serving this runner. Move the scrape off "
-                     "GitHub Actions, or route it through a proxy.")
-        EOF
-
-    - name: Scrape new announcements and push to HuggingFace
+    # Publish the announcement dataset to HuggingFace. Both halves are on disk
+    # by now: the structured fields from the historical mirror this run just
+    # refreshed, and the announcement text from the scraped collection above.
+    # Nothing is fetched here, so it needs no R2 credentials and no second
+    # crawl of usajobs.gov.
+    #
+    # This replaced a step that cloned abigailhaddad/joa and scraped from
+    # there. That path published no positionTitle -- the dataset had no job
+    # title in it at all -- and could not carry the eleven structured
+    # announcement sections, which come from a parse that lives in this repo.
+    - name: Publish announcement dataset to HuggingFace
+      if: always()
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
-        git clone --depth 1 https://github.com/abigailhaddad/joa.git /tmp/joa
-        pip install -r /tmp/joa/requirements.txt
-        ln -s "$GITHUB_WORKSPACE/data" /tmp/joa/data
-        cd /tmp/joa
-        # Metadata keeps changing after a posting appears, so rewrite every
-        # month once a month; the daily run only refreshes what it touched.
+        # Metadata keeps changing after a posting appears (close dates,
+        # opening status), so rewrite every month once a month; the daily run
+        # only republishes the months that gained rows.
         REFRESH=""
         [ "$(date -u +%d)" = "01" ] && REFRESH="--refresh-all"
-        python3 update_daily.py $REFRESH
+        # Never fails the run: the dataset is downstream of everything that
+        # matters here, and publish_to_huggingface.py exits non-zero when it
+        # refuses a month rather than shrink it.
+        python scripts/publish_to_huggingface.py $REFRESH || \
+          echo "::warning::HuggingFace publish did not complete cleanly"
 
     - name: Commit and push to data-updates branch
       # Only runs if tests pass

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ session_base64.txt
 questionnaires/session_base64.txt
 .vercel
 .wrangler/
+
+# HuggingFace publish staging and page-backfill shards
+build/
+data/.scraped_shards_*/

--- a/README.md
+++ b/README.md
@@ -212,18 +212,39 @@ python scripts/publish_to_huggingface.py
 python scripts/publish_to_huggingface.py --refresh-all   # rewrite every month
 ```
 
+### What stays on disk
+
+Announcement text is 97.8% of `scraped_jobs_{year}.parquet` — 5.42 KB of a
+5.54 KB row — so a full year would be 920 MB local against 20 MB for
+everything else in it. HuggingFace is the store for the text instead: after a
+month publishes, the publisher blanks those rows' text columns locally, and
+what stays is the structured shadow the API comparison reads plus anything not
+yet pushed. Measured on real rows, that takes a 162,000-row year from 920 MB to
+34 MB. `--keep-text` opts out.
+
 ### Backfilling announcement pages
 
 The scraped collection only starts the day it was switched on, so postings from
 earlier in the year have metadata but no text. usajobs.gov serves closed
 announcements indefinitely, so they can be filled in — roughly 160k pages for a
-full year, about three hours. Run it on its own, not inside the daily workflow.
-It writes immutable shards and folds them in at the end, so it is resumable:
-kill it whenever and rerun.
+full year.
+
+It works a month at a time and publishes each one as it lands, so the working
+set stays near a single month rather than piling up the year, and a killed run
+resumes at month granularity. Within a month it writes immutable shards and
+folds them in once at the end.
+
+It is network-bound, not CPU-bound: a page costs ~32 ms to parse, so a full
+year is about 86 CPU-minutes over those three hours. It runs niced and under a
+CPU governor by default. `--max-cpu` is a share of **one** core, not of the
+machine — measured, an uncapped run sits at 53% of a core, and `--max-cpu 15`
+holds it to 18% at three times the wall clock.
 
 ```bash
 python scripts/backfill_scraped_pages.py --year 2026 --dry-run
 python scripts/backfill_scraped_pages.py --year 2026
+python scripts/backfill_scraped_pages.py --year 2026 --max-cpu 20   # gentler
+python scripts/backfill_scraped_pages.py --year 2026 --no-publish   # keep local
 ```
 
 ## Data Storage

--- a/README.md
+++ b/README.md
@@ -153,9 +153,22 @@ which the Current API collection doesn't populate. The text fields have no API
 counterpart to check against, so the report tracks their fill rate instead: if
 usajobs.gov changes its markup they go empty, and that's the signal.
 
+Duty stations come out as a `PositionLocations` column in the historical API's
+`{positionLocationCity, positionLocationState}` shape, so `prep_web_data.py`
+consumes them through the path it already has. Rendered through that same
+extractor, the location string matched the API exactly on 337 of 348 postings.
+The other 11 are the page's own doing rather than a parse failure: a posting
+with 31 API entries across 22 cities renders 12, and some collapse to a label
+like "Location Negotiable After Selection". The search endpoint's own
+`positionLocationCount` matched the API on all 348, so the accurate count is
+kept alongside the page's list in `scrapedLocationCount` and the gap stays
+measurable.
+
 What scraping can't give you: `hiringAgencyCode`, `hiringDepartmentCode`,
 `agencyLevel`, `agencyLevelSort`, `vendor`, `whoMayApply`. Those are API-only
-and the announcement page never shows them. It also can't backfill — search
+and the announcement page never shows them. Nothing reads them off the current
+parquets — `repoll_status.py` is the only consumer and it writes them into the
+historical files, from the keyless `/api/historicjoa`. It also can't backfill — search
 only lists open postings, so this accumulates forward from the day it started.
 Closed announcement pages do stay up indefinitely, which is what the
 [announcement-text dataset](https://github.com/abigailhaddad/joa) relies on.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,55 @@ Coverage shortfalls and field disagreements past the thresholds in
 `compare_scrape_to_api.py` open a GitHub issue. Neither the scrape nor the
 comparison can fail the daily run.
 
+## The HuggingFace announcement dataset
+
+[abigailhaddad/usajobs-scraping](https://huggingface.co/datasets/abigailhaddad/usajobs-scraping)
+is one parquet per month plus a manifest, published daily by
+`scripts/publish_to_huggingface.py`. It joins the two halves this pipeline
+already has on disk: structured fields from `historical_jobs_{year}.parquet`,
+and announcement text from `scraped_jobs_{year}.parquet`. Nothing is fetched at
+publish time.
+
+This replaced a publish path that lived in a separate repo
+([joa](https://github.com/abigailhaddad/joa)) and keyed off the historical
+mirror alone. Two things were wrong with it. Its field list never selected
+`positionTitle`, so the published dataset had no job title in it — easy to miss,
+because its controls CSV aliased `announcementNumber` as "title". And it could
+not carry the eleven structured announcement sections, which come from a parse
+that lives here.
+
+The dataset went from 40 columns to 53: `positionTitle` and
+`hiringSubelementName`, plus `jobSummary`, `majorDuties`, `requirements`,
+`conditionsOfEmployment`, `qualificationSummary`, `education`,
+`additionalInformation`, `benefits`, `howYouWillBeEvaluated`,
+`requiredDocuments` and `howToApply`. The whole-page `text` column stays, so
+anything built against it keeps working — columns are only ever added.
+
+A month file is rewritten wholesale, so the publisher refuses to write a month
+when the local join is missing announcements the dataset already holds, rather
+than silently shrinking it. That is the expected state while the page backfill
+is still running.
+
+```bash
+python scripts/publish_to_huggingface.py --dry-run
+python scripts/publish_to_huggingface.py
+python scripts/publish_to_huggingface.py --refresh-all   # rewrite every month
+```
+
+### Backfilling announcement pages
+
+The scraped collection only starts the day it was switched on, so postings from
+earlier in the year have metadata but no text. usajobs.gov serves closed
+announcements indefinitely, so they can be filled in — roughly 160k pages for a
+full year, about three hours. Run it on its own, not inside the daily workflow.
+It writes immutable shards and folds them in at the end, so it is resumable:
+kill it whenever and rerun.
+
+```bash
+python scripts/backfill_scraped_pages.py --year 2026 --dry-run
+python scripts/backfill_scraped_pages.py --year 2026
+```
+
 ## Data Storage
 
 - **Cloudflare R2**: All parquet files are stored in R2 (not in this git repo due to size)
@@ -215,6 +264,8 @@ comparison can fail the daily run.
 │   ├── collect_scraped_data.py  # Same jobs, scraped from usajobs.gov (shadow)
 │   ├── usajobs_scrape.py        # Search endpoint + announcement-page parsing
 │   ├── compare_scrape_to_api.py # Diff the scraped and API collections
+│   ├── publish_to_huggingface.py # Push the announcement dataset to HuggingFace
+│   ├── backfill_scraped_pages.py # Fetch pages for postings scraped before the scrape existed
 │   ├── prep_web_data.py         # Build slim 14-column parquet for website
 │   ├── sync_to_r2.py            # Upload parquet files to Cloudflare R2
 │   ├── run_parallel.sh          # Run multiple years in parallel

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ h11==0.16.0
 htmltools==0.6.0
 httpcore==1.0.9
 httpx==0.28.1
+huggingface_hub==1.11.0
 idna==3.10
 importlib_metadata==8.7.0
 importlib_resources==6.5.2

--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -73,6 +73,8 @@ def parse_args():
     p.add_argument("--nice", type=int, default=10,
                    help="Process niceness, 0-19 (default 10). Higher yields "
                         "more readily to whatever else is running.")
+    p.add_argument("--month", help="Only this month (YYYY-MM). Useful for a "
+                                   "pilot, or to resume a specific month.")
     p.add_argument("--no-publish", action="store_true",
                    help="Do not push each month to HuggingFace as it finishes. "
                         "Announcement text is 97.8%% of what this writes — 920 MB "
@@ -211,14 +213,21 @@ def publish_month(data_dir, year, month):
     rather than anything cached.
     """
     import subprocess
-    if not os.environ.get("HF_TOKEN"):
-        print(f"  HF_TOKEN not set — keeping {month} on disk unpublished")
+    from huggingface_hub import get_token
+    if not (os.environ.get("HF_TOKEN") or get_token()):
+        print(f"  No HuggingFace token — keeping {month} on disk unpublished")
         return
     script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           "publish_to_huggingface.py")
+    # --refresh-all, scoped to this one month by --month. The manifest records
+    # which announcements are published, not what is in them, so a month whose
+    # postings were already listed would otherwise be skipped — which is
+    # exactly the case here: those rows are on the dataset with text but no
+    # sections, and this run is what gives them sections.
+    sys.stdout.flush()
     result = subprocess.run(
-        [sys.executable, script, "--year", str(year), "--month", month,
-         "--data-dir", data_dir],
+        [sys.executable, "-u", script, "--year", str(year), "--month", month,
+         "--refresh-all", "--data-dir", data_dir],
         check=False)
     if result.returncode != 0:
         print(f"  publish of {month} did not complete cleanly — its text "
@@ -234,6 +243,9 @@ def main() -> int:
         return 0
 
     wanted = wanted_postings(args.data_dir, args.year)
+    if args.month:
+        wanted = {cn: d for cn, d in wanted.items() if d[:7] == args.month}
+        print(f"Restricted to {args.month}: {len(wanted):,} postings")
     known = stored_control_numbers(args.data_dir, args.year)
     todo = sorted(cn for cn in wanted if cn not in known)
 
@@ -244,6 +256,11 @@ def main() -> int:
         print(f"  limited to {len(todo):,} this run")
     if not todo:
         compact(args.data_dir, args.year)
+        # Nothing to fetch does not mean nothing to publish: a month can be
+        # fully scraped and still be on the dataset without its sections,
+        # which is the state every month is in on the first pass.
+        if args.month and not args.no_publish:
+            publish_month(args.data_dir, args.year, args.month)
         return 0
     if args.dry_run:
         for cn in todo[:10]:
@@ -326,6 +343,7 @@ def main() -> int:
                       desc=f"{month}", unit="page"))
         flush()
         compact(args.data_dir, args.year)
+        sys.stdout.flush()
         if not args.no_publish:
             publish_month(args.data_dir, args.year, month)
 

--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -15,6 +15,14 @@ what exists.
 Long-running by design — roughly 160k pages for a full year, about three hours
 at the default concurrency. Run it on its own, not inside the daily workflow.
 
+It is network-bound, not CPU-bound: a page costs ~32 ms to parse, so a full
+year is about 86 CPU-minutes spread over those three hours, or roughly half of
+one core. It still runs niced and under a CPU governor by default, so it stays
+out of the way of whatever else the machine is doing. --max-cpu is a share of
+ONE core, not of the machine: at the default 50 the governor barely bites,
+since the fetch rate already holds it near there. Halving it roughly doubles
+the wall clock.
+
 Resumable and crash-safe. Pages land in immutable shard files tagged with a
 per-run id; a rerun skips every control number already in a shard or in the
 main parquet. Kill it whenever. Shards fold into the main parquet at the end,
@@ -23,6 +31,8 @@ or on the next run with --compact-only.
     python backfill_scraped_pages.py --year 2026 --dry-run
     python backfill_scraped_pages.py --year 2026
     python backfill_scraped_pages.py --year 2026 --limit 500   # a taste
+    python backfill_scraped_pages.py --year 2026 --max-cpu 25  # gentler, slower
+    python backfill_scraped_pages.py --year 2026 --max-cpu 0   # no governor
     python backfill_scraped_pages.py --year 2026 --compact-only
 """
 
@@ -56,11 +66,65 @@ def parse_args():
     p.add_argument("--workers", type=int, default=8)
     p.add_argument("--limit", type=int, default=0,
                    help="Stop after this many pages (0 = everything)")
+    p.add_argument("--max-cpu", type=float, default=50.0,
+                   help="Hold average CPU under this percent of ONE core "
+                        "(default 50; 0 disables). Lower is gentler and "
+                        "proportionally slower.")
+    p.add_argument("--nice", type=int, default=10,
+                   help="Process niceness, 0-19 (default 10). Higher yields "
+                        "more readily to whatever else is running.")
+    p.add_argument("--no-publish", action="store_true",
+                   help="Do not push each month to HuggingFace as it finishes. "
+                        "Announcement text is 97.8%% of what this writes — 920 MB "
+                        "for a year — so by default each month is published and "
+                        "its text dropped locally, keeping the working set to "
+                        "about one month.")
     p.add_argument("--dry-run", action="store_true",
                    help="Report what is missing and fetch nothing")
     p.add_argument("--compact-only", action="store_true",
                    help="Fold existing shards into the main parquet and stop")
     return p.parse_args()
+
+
+class CpuGovernor:
+    """Hold this process's average CPU use under a share of one core.
+
+    Measures the process's own CPU time against wall time and sleeps the
+    calling worker when the ratio runs ahead of target. That lowers the duty
+    cycle rather than the cost per page: the same work happens, spread over
+    more wall clock, which is what "use less CPU" means for a job that is
+    already network-bound.
+
+    time.process_time() counts every thread, so the target is a share of one
+    core regardless of --workers.
+    """
+
+    def __init__(self, percent_of_one_core: float):
+        self.target = (percent_of_one_core or 0) / 100.0
+        self.lock = threading.Lock()
+        self.wall0 = time.monotonic()
+        self.cpu0 = time.process_time()
+
+    def throttle(self) -> None:
+        if self.target <= 0:
+            return
+        with self.lock:
+            wall = time.monotonic() - self.wall0
+            cpu = time.process_time() - self.cpu0
+            if wall <= 0:
+                return
+            # Want cpu/wall <= target, so wall must be at least cpu/target.
+            deficit = cpu / self.target - wall
+        if deficit > 0:
+            # Capped so a long stall cannot park a worker for minutes.
+            time.sleep(min(deficit, 2.0))
+
+    def report(self) -> str:
+        wall = time.monotonic() - self.wall0
+        cpu = time.process_time() - self.cpu0
+        share = 100 * cpu / wall if wall else 0
+        return (f"{cpu/60:.1f} CPU-minutes over {wall/60:.1f} wall-minutes "
+                f"({share:.0f}% of one core)")
 
 
 def thread_session():
@@ -138,6 +202,29 @@ def compact(data_dir, year):
     return len(rows)
 
 
+def publish_month(data_dir, year, month):
+    """Push one month to HuggingFace, which also drops its text from disk.
+
+    Run in a subprocess rather than imported: publish_to_huggingface holds a
+    duckdb connection and reads the parquet this process has been writing, and
+    a fresh process is the simplest way to be sure it sees the compacted file
+    rather than anything cached.
+    """
+    import subprocess
+    if not os.environ.get("HF_TOKEN"):
+        print(f"  HF_TOKEN not set — keeping {month} on disk unpublished")
+        return
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "publish_to_huggingface.py")
+    result = subprocess.run(
+        [sys.executable, script, "--year", str(year), "--month", month,
+         "--data-dir", data_dir],
+        check=False)
+    if result.returncode != 0:
+        print(f"  publish of {month} did not complete cleanly — its text "
+              f"stays on disk and the next run retries it")
+
+
 def main() -> int:
     args = parse_args()
 
@@ -163,6 +250,27 @@ def main() -> int:
             print(f"   {wanted[cn]}  {cn}")
         return 0
 
+    if args.nice:
+        try:
+            os.nice(args.nice)
+        except (AttributeError, OSError) as e:
+            print(f"  could not renice ({e}) — continuing at normal priority")
+
+    governor = CpuGovernor(args.max_cpu)
+    if governor.target > 0:
+        print(f"  holding CPU under {args.max_cpu:.0f}% of one core, "
+              f"niceness +{args.nice}")
+
+    # Work a month at a time and publish each one as it lands. Fetching the
+    # whole year first would pile up 920 MB of announcement text on disk before
+    # anything could be pushed; this keeps the working set to roughly one
+    # month, and makes a killed run resume at month granularity.
+    by_month = {}
+    for cn in todo:
+        by_month.setdefault(wanted[cn][:7], []).append(cn)
+    print(f"  across {len(by_month)} month(s): "
+          + ", ".join(f"{m} ({len(c):,})" for m, c in sorted(by_month.items())))
+
     shards = shard_dir(args.data_dir, args.year)
     os.makedirs(shards, exist_ok=True)
     run_id = uuid.uuid4().hex[:8]
@@ -182,6 +290,7 @@ def main() -> int:
 
     def work(cn):
         nonlocal gone, failed
+        governor.throttle()
         html, error = fetch_job_page(thread_session(), cn)
         if html is None:
             with lock:
@@ -211,16 +320,19 @@ def main() -> int:
             if len(batch) >= SHARD_ROWS:
                 flush()
 
-    with ThreadPoolExecutor(max_workers=args.workers) as pool:
-        list(tqdm(pool.map(work, todo), total=len(todo),
-                  desc="Announcement pages", unit="page"))
-    flush()
+    for month, cns in sorted(by_month.items()):
+        with ThreadPoolExecutor(max_workers=args.workers) as pool:
+            list(tqdm(pool.map(work, cns), total=len(cns),
+                      desc=f"{month}", unit="page"))
+        flush()
+        compact(args.data_dir, args.year)
+        if not args.no_publish:
+            publish_month(args.data_dir, args.year, month)
 
     elapsed = (time.time() - started) / 60
-    print(f"Fetched {len(todo) - gone - failed:,} pages in {elapsed:.1f} min, "
+    print(f"\nFetched {len(todo) - gone - failed:,} pages in {elapsed:.1f} min, "
           f"{failed} failed, {gone} already removed (404)")
-
-    compact(args.data_dir, args.year)
+    print(f"  used {governor.report()}")
     if failed:
         print("Failed pages stay unstored — rerun to retry them")
     return 0

--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Fetch announcement pages for postings collected before the scrape existed.
+
+collect_scraped_data.py only sees what is open right now, so the scraped
+collection starts the day it was switched on. usajobs.gov serves closed
+announcements indefinitely, though, so the earlier ones can be filled in — and
+have to be, or the published dataset has two shapes and every consumer has to
+handle both.
+
+The posting list comes from data/historical_jobs_{year}.parquet: the historical
+API needs no key and reports closed postings, so it is the complete list of
+what exists.
+
+Long-running by design — roughly 160k pages for a full year, about three hours
+at the default concurrency. Run it on its own, not inside the daily workflow.
+
+Resumable and crash-safe. Pages land in immutable shard files tagged with a
+per-run id; a rerun skips every control number already in a shard or in the
+main parquet. Kill it whenever. Shards fold into the main parquet at the end,
+or on the next run with --compact-only.
+
+    python backfill_scraped_pages.py --year 2026 --dry-run
+    python backfill_scraped_pages.py --year 2026
+    python backfill_scraped_pages.py --year 2026 --limit 500   # a taste
+    python backfill_scraped_pages.py --year 2026 --compact-only
+"""
+
+import argparse
+import os
+import sys
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+
+import pandas as pd
+import pyarrow.parquet as pq
+from tqdm import tqdm
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from collect_current_data import save_jobs_to_parquet
+from usajobs_scrape import fetch_job_page, new_session, parse_job_page
+
+SHARD_ROWS = 2000
+_local = threading.local()
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Backfill announcement pages for a year of postings")
+    p.add_argument("--year", type=int, required=True)
+    p.add_argument("--data-dir", default="data")
+    p.add_argument("--workers", type=int, default=8)
+    p.add_argument("--limit", type=int, default=0,
+                   help="Stop after this many pages (0 = everything)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report what is missing and fetch nothing")
+    p.add_argument("--compact-only", action="store_true",
+                   help="Fold existing shards into the main parquet and stop")
+    return p.parse_args()
+
+
+def thread_session():
+    if not hasattr(_local, "session"):
+        _local.session = new_session()
+    return _local.session
+
+
+def shard_dir(data_dir, year):
+    return os.path.join(data_dir, f".scraped_shards_{year}")
+
+
+def stored_control_numbers(data_dir, year):
+    """Control numbers already scraped: in the main parquet or in any shard."""
+    known = set()
+    main = os.path.join(data_dir, f"scraped_jobs_{year}.parquet")
+    if os.path.exists(main):
+        known |= set(pd.read_parquet(main, columns=["usajobs_control_number"])
+                     ["usajobs_control_number"].dropna().astype(str))
+
+    shards = shard_dir(data_dir, year)
+    if os.path.isdir(shards):
+        for name in sorted(os.listdir(shards)):
+            if not name.endswith(".parquet"):
+                continue
+            path = os.path.join(shards, name)
+            try:
+                known |= set(pq.read_table(path, columns=["usajobs_control_number"])
+                             .column(0).to_pylist())
+            except Exception as e:
+                print(f"  unreadable shard {name} ({e}), ignoring")
+    return known
+
+
+def wanted_postings(data_dir, year):
+    """Every posting the historical mirror has for the year."""
+    path = os.path.join(data_dir, f"historical_jobs_{year}.parquet")
+    if not os.path.exists(path):
+        sys.exit(f"{path} is missing — this needs the historical mirror.")
+    df = pd.read_parquet(path, columns=["usajobsControlNumber", "positionOpenDate"])
+    df = df.dropna(subset=["usajobsControlNumber"]).drop_duplicates(
+        "usajobsControlNumber")
+    return {str(int(r.usajobsControlNumber)): str(r.positionOpenDate)[:10]
+            for r in df.itertuples()}
+
+
+def compact(data_dir, year):
+    """Fold shards into the main parquet, then delete them.
+
+    save_jobs_to_parquet rewrites the whole file, so this runs once at the end
+    rather than per batch — at a year's scale, rewriting a growing multi-hundred
+    megabyte parquet after every batch is the difference between minutes and
+    hours.
+    """
+    shards = shard_dir(data_dir, year)
+    if not os.path.isdir(shards):
+        return 0
+    files = sorted(f for f in os.listdir(shards) if f.endswith(".parquet"))
+    if not files:
+        return 0
+
+    print(f"Folding {len(files)} shard(s) into scraped_jobs_{year}.parquet")
+    frames = [pd.read_parquet(os.path.join(shards, f)) for f in files]
+    rows = pd.concat(frames, ignore_index=True).drop_duplicates(
+        "usajobs_control_number")
+
+    # save_jobs_to_parquet stamps inserted_at/last_seen and merges on control
+    # number, so a posting already in the file is updated rather than doubled.
+    save_jobs_to_parquet(rows.to_dict("records"),
+                         os.path.join(data_dir, f"scraped_jobs_{year}.parquet"))
+
+    for f in files:
+        os.remove(os.path.join(shards, f))
+    os.rmdir(shards)
+    return len(rows)
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.compact_only:
+        n = compact(args.data_dir, args.year)
+        print(f"Compacted {n:,} rows" if n else "No shards to compact")
+        return 0
+
+    wanted = wanted_postings(args.data_dir, args.year)
+    known = stored_control_numbers(args.data_dir, args.year)
+    todo = sorted(cn for cn in wanted if cn not in known)
+
+    print(f"{args.year}: {len(wanted):,} postings in the historical mirror, "
+          f"{len(known):,} already scraped, {len(todo):,} to fetch")
+    if args.limit:
+        todo = todo[:args.limit]
+        print(f"  limited to {len(todo):,} this run")
+    if not todo:
+        compact(args.data_dir, args.year)
+        return 0
+    if args.dry_run:
+        for cn in todo[:10]:
+            print(f"   {wanted[cn]}  {cn}")
+        return 0
+
+    shards = shard_dir(args.data_dir, args.year)
+    os.makedirs(shards, exist_ok=True)
+    run_id = uuid.uuid4().hex[:8]
+
+    lock = threading.Lock()
+    batch, part, gone, failed = [], 0, 0, 0
+    started = time.time()
+
+    def flush():
+        nonlocal batch, part
+        if not batch:
+            return
+        part += 1
+        path = os.path.join(shards, f"part-{run_id}-{part:05d}.parquet")
+        pd.DataFrame(batch).to_parquet(path, index=False, compression="zstd")
+        batch = []
+
+    def work(cn):
+        nonlocal gone, failed
+        html, error = fetch_job_page(thread_session(), cn)
+        if html is None:
+            with lock:
+                # A 404 (error is None) is a real answer, not a failure: the
+                # page is gone and retrying will not bring it back.
+                if error is None:
+                    gone += 1
+                else:
+                    failed += 1
+            return
+
+        try:
+            row = parse_job_page(html)
+        except Exception as e:
+            with lock:
+                failed += 1
+            print(f"   parse failed for {cn}: {e}")
+            return
+
+        # The page carries its own control number, but trust the list we asked
+        # for: a redirect would otherwise file the row under the wrong posting.
+        row["usajobs_control_number"] = cn
+        row["usajobsControlNumber"] = int(cn)
+        row["positionOpenDate"] = row.get("positionOpenDate") or wanted[cn]
+        with lock:
+            batch.append(row)
+            if len(batch) >= SHARD_ROWS:
+                flush()
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        list(tqdm(pool.map(work, todo), total=len(todo),
+                  desc="Announcement pages", unit="page"))
+    flush()
+
+    elapsed = (time.time() - started) / 60
+    print(f"Fetched {len(todo) - gone - failed:,} pages in {elapsed:.1f} min, "
+          f"{failed} failed, {gone} already removed (404)")
+
+    compact(args.data_dir, args.year)
+    if failed:
+        print("Failed pages stay unstored — rerun to retry them")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare_scrape_to_api.py
+++ b/scripts/compare_scrape_to_api.py
@@ -78,6 +78,13 @@ TEXT_FIELDS = [
 MIN_TEXT_FILL = {"education": 0.50}
 MIN_TEXT_FILL_DEFAULT = 0.90
 
+# Share of postings whose announcement page must list as many duty stations as
+# the search endpoint says the posting has. It is not 100%: for about 3% of
+# postings the page renders a shorter list than the API holds (one with 31 API
+# entries across 22 cities showed 12), and that is the page's own doing, not a
+# parse failure. A sharp drop here means the location markup changed.
+MIN_LOCATION_COMPLETE = 0.90
+
 # Below these, say so loudly.
 MIN_COVERAGE = 0.95      # share of the API's window postings the scrape found
 MIN_AGREEMENT = 0.90     # share of comparable rows a field must match on
@@ -205,6 +212,35 @@ def text_field_health(data_dir: str) -> list:
     return rows
 
 
+def location_completeness(data_dir: str) -> dict:
+    """How often the page lists every duty station the posting has.
+
+    Self-contained: compares the page-parsed count against the count the search
+    endpoint reported for the same posting, so it needs no API data. The search
+    count matched the API exactly on all 348 postings of the first check, which
+    is what makes it usable as the reference.
+    """
+    import pyarrow.parquet as pq
+
+    total = complete = short = 0
+    for name in sorted(os.listdir(data_dir)):
+        if not (name.startswith("scraped_jobs_") and name.endswith(".parquet")):
+            continue
+        path = os.path.join(data_dir, name)
+        present = set(pq.read_schema(path).names)
+        if not {"positionLocationCount", "scrapedLocationCount"} <= present:
+            continue
+        df = pd.read_parquet(path, columns=["positionLocationCount",
+                                            "scrapedLocationCount"])
+        df = df.dropna()
+        total += len(df)
+        complete += int((df.scrapedLocationCount >= df.positionLocationCount).sum())
+        short += int((df.scrapedLocationCount < df.positionLocationCount).sum())
+
+    return {"total": total, "complete": complete, "short": short,
+            "rate": complete / total if total else None}
+
+
 def flag(message: str) -> None:
     os.makedirs(os.path.dirname(DIVERGENCE_FILE), exist_ok=True)
     with open(DIVERGENCE_FILE, "a") as f:
@@ -317,6 +353,21 @@ def main() -> int:
                   "therefore not compared: hiringAgencyCode, "
                   "hiringDepartmentCode, agencyLevel, agencyLevelSort, vendor, "
                   "whoMayApply, announcementClosingTypeDescription.", ""]
+
+    # Duty stations. Checked against the search endpoint's own count rather
+    # than the API, so this keeps working if the API collection ever stops.
+    loc = location_completeness(args.data_dir)
+    if loc["total"]:
+        lines += ["## Duty stations", "",
+                  f"Page listed every station the search endpoint reported on "
+                  f"**{loc['rate']:.1%}** of {loc['total']:,} postings "
+                  f"({loc['short']:,} listed fewer).", ""]
+        if loc["rate"] < MIN_LOCATION_COMPLETE:
+            flag(f"The announcement page listed fewer duty stations than the "
+                 f"search endpoint reported on {loc['short']:,} of "
+                 f"{loc['total']:,} postings ({1 - loc['rate']:.1%}); floor is "
+                 f"{1 - MIN_LOCATION_COMPLETE:.0%}. The location markup has "
+                 f"probably changed.")
 
     # The long-text sections, which the API has no counterpart for.
     lines += ["## Announcement text (scraped only, no API counterpart)", "",

--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -177,22 +177,69 @@ def connection():
     return con
 
 
-def select_sql(hist_path: str, scraped_path: str, month: str = None) -> str:
-    """The join. Scraped columns are coalesced against nothing — a posting with
-    no scraped row is excluded, because a row with no announcement text is what
-    the historical mirror already publishes."""
-    text_cols = ",\n    ".join(f"s.{c}" for c in TEXT_FIELDS)
-    where = ""
-    if month:
-        where = f"WHERE substr(h.positionOpenDate, 1, 7) = '{month}'"
+def parquet_columns(path):
+    import pyarrow.parquet as pq
+    return set(pq.read_schema(path).names)
+
+
+def select_sql(hist_path: str, scraped_path: str, month: str,
+               prior_path: str = None) -> str:
+    """Fresh metadata joined to announcement text from wherever it still lives.
+
+    Text comes from the local scrape when it has it, and otherwise from the
+    month file already on HuggingFace. That second source is what makes the
+    local prune safe: once a posting is published the dataset holds its text,
+    and a later republish — a metadata refresh, or a month gaining rows — reads
+    it back rather than needing a local copy that no longer exists.
+
+    A local row whose text has been pruned has NULL text, so it must not win
+    over the published copy; hence the WHERE on the local side.
+    """
+    cols = ",\n        ".join(TEXT_FIELDS)
+    parts = [f"""local_text AS (
+        SELECT usajobs_control_number AS cn,
+        {cols}
+        FROM read_parquet('{scraped_path}')
+        WHERE text IS NOT NULL
+    )"""]
+    union = "SELECT * FROM local_text"
+    if prior_path:
+        # A month published before a column existed does not have it. That is
+        # the normal case on the first pass: every month on the dataset today
+        # was written with `text` only, and the eleven sections are what this
+        # run adds. Select what is there and null the rest so the shapes line
+        # up for the UNION.
+        available = parquet_columns(prior_path)
+        prior_cols = ",\n        ".join(
+            c if c in available else f"CAST(NULL AS VARCHAR) AS {c}"
+            for c in TEXT_FIELDS)
+        parts.append(f"""prior_text AS (
+        SELECT usajobsControlNumber AS cn,
+        {prior_cols}
+        FROM read_parquet('{prior_path}')
+        WHERE usajobsControlNumber NOT IN (SELECT cn FROM local_text)
+    )""")
+        union += " UNION ALL SELECT * FROM prior_text"
+
+    text_cols = ",\n    ".join(f"t.{c}" for c in TEXT_FIELDS)
     return f"""
+        WITH {", ".join(parts)}, txt AS ({union})
         SELECT {METADATA_FIELDS},
     {text_cols}
         FROM read_parquet('{hist_path}') h
-        JOIN read_parquet('{scraped_path}') s
-          ON h.usajobsControlNumber::varchar = s.usajobs_control_number
-        {where}
+        JOIN txt t ON h.usajobsControlNumber::varchar = t.cn
+        WHERE substr(h.positionOpenDate, 1, 7) = '{month}'
     """
+
+
+def download_month(repo, month, token):
+    """The month file already on HuggingFace, or None if there is not one."""
+    from huggingface_hub import hf_hub_download
+    name = f"data/{month.replace('-', '_')}.parquet"
+    try:
+        return hf_hub_download(repo, name, repo_type="dataset", token=token)
+    except Exception:
+        return None
 
 
 def month_of_every_posting(con, hist_path):
@@ -221,7 +268,7 @@ def available_months(con, hist_path, scraped_path):
         FROM read_parquet('{hist_path}') h
         JOIN read_parquet('{scraped_path}') s
           ON h.usajobsControlNumber::varchar = s.usajobs_control_number
-        WHERE h.positionOpenDate IS NOT NULL
+        WHERE h.positionOpenDate IS NOT NULL AND s.text IS NOT NULL
     """).fetchall()
     months = {}
     for month, cn in rows:
@@ -276,7 +323,9 @@ def main() -> int:
             print(f"Missing {path} — nothing to publish.")
             return 0
 
-    token = os.environ.get("HF_TOKEN")
+    # HF_TOKEN in CI; the cached login from `huggingface-cli login` locally.
+    from huggingface_hub import get_token
+    token = os.environ.get("HF_TOKEN") or get_token()
     if not token and not args.dry_run:
         print("HF_TOKEN is not set — nothing published.")
         return 0
@@ -307,8 +356,24 @@ def main() -> int:
         todo = sorted(m for m, cns in months.items() if cns - have)
         print(f"{len(todo)} month(s) have new rows: {', '.join(todo) or '(none)'}")
 
+    # Pull the month files we are about to rewrite. Their text is the source
+    # for every posting whose local copy has been pruned, and their control
+    # numbers are what makes the rebuild provably non-destructive.
+    priors, availability = {}, {}
+    for month in todo:
+        prior = download_month(args.repo, month, token) if token else None
+        priors[month] = prior
+        prior_cns = set()
+        if prior:
+            prior_cns = {r[0] for r in con.execute(
+                f"SELECT usajobsControlNumber::varchar "
+                f"FROM read_parquet('{prior}')").fetchall()}
+            print(f"  {month}: {len(prior_cns):,} already published, "
+                  f"{len(months[month] - prior_cns):,} new")
+        availability[month] = months[month] | prior_cns
+
     month_of = month_of_every_posting(con, str(hist))
-    safe, refused = partition_safe_months(todo, months, have, month_of)
+    safe, refused = partition_safe_months(todo, availability, have, month_of)
 
     for month, n, total in refused:
         print(f"  REFUSING {month}: rebuilding it would drop {n:,} of the "
@@ -330,7 +395,7 @@ def main() -> int:
         # COPY streams straight to disk. Materializing a month in Python would
         # be ~800 MB of announcement text.
         con.execute(f"""
-            COPY ({select_sql(str(hist), str(scraped), month)}
+            COPY ({select_sql(str(hist), str(scraped), month, priors.get(month))}
                   ORDER BY usajobsControlNumber)
             TO '{dest}' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 19);
         """)

--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -95,6 +95,58 @@ TEXT_FIELDS = [
 ]
 
 
+def prune_published_text(scraped_path, published_cns):
+    """Blank the announcement text on rows that are now on HuggingFace.
+
+    The text columns are 97.8% of scraped_jobs_{year}.parquet — 5.42 KB of a
+    5.54 KB row — so a full year is 920 MB kept locally against 20 MB for
+    everything else in it. Once a posting is published, the dataset is the
+    store; what stays here is the structured shadow the API comparison reads,
+    plus the text for anything not yet pushed.
+
+    Rewrites row group by row group so peak memory does not track file size.
+    """
+    import pyarrow as pa
+    import pyarrow.compute as pc
+    import pyarrow.parquet as pq
+    import tempfile
+
+    if not published_cns or not os.path.exists(scraped_path):
+        return 0
+
+    pf = pq.ParquetFile(scraped_path)
+    present = [c for c in TEXT_FIELDS if c in pf.schema_arrow.names]
+    if not present:
+        return 0
+
+    drop = pa.array(sorted(published_cns), type=pa.string())
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(scraped_path) or ".",
+                               prefix=".tmp_", suffix=".parquet")
+    os.close(fd)
+    cleared = 0
+    try:
+        with pq.ParquetWriter(tmp, pf.schema_arrow, compression="zstd",
+                              compression_level=3) as writer:
+            for batch in pf.iter_batches(batch_size=2000):
+                table = pa.Table.from_batches([batch])
+                ids = table.column("usajobs_control_number").cast(pa.string())
+                hit = pc.fill_null(pc.is_in(ids, value_set=drop), False)
+                cleared += int(pc.sum(hit).as_py() or 0)
+                for name in present:
+                    col = table.column(name)
+                    blanked = pc.if_else(hit, pa.nulls(len(col), col.type), col)
+                    table = table.set_column(
+                        table.schema.get_field_index(name),
+                        table.schema.field(name), blanked)
+                writer.write_table(table)
+        os.replace(tmp, scraped_path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
+    return cleared
+
+
 def parse_args():
     p = argparse.ArgumentParser(description="Publish the dataset to HuggingFace")
     p.add_argument("--year", type=int,
@@ -107,6 +159,14 @@ def parse_args():
                         "Metadata keeps changing after a posting appears "
                         "(close dates, opening status), so run this on a slower "
                         "schedule than the daily top-up.")
+    p.add_argument("--month", help="Publish only this month (YYYY-MM)")
+    p.add_argument("--keep-text", action="store_true",
+                   help="Do not drop the published announcement text from the "
+                        "local parquet afterwards. The text is 97.8%% of that "
+                        "file — 920 MB for a year against 20 MB for the "
+                        "structured columns — so by default HuggingFace is the "
+                        "store for it and the local copy keeps only what has "
+                        "not been published yet.")
     p.add_argument("--data-dir", default=str(DATA_DIR))
     return p.parse_args()
 
@@ -234,6 +294,12 @@ def main() -> int:
     new = {cn for cns in months.values() for cn in cns} - have
     print(f"Local join has {total_available:,}; {len(new):,} are new")
 
+    if args.month:
+        months = {m: cns for m, cns in months.items() if m == args.month}
+        if not months:
+            print(f"No postings opened in {args.month} have scraped text.")
+            return 0
+
     if args.refresh_all:
         todo = sorted(months)
         print(f"Refreshing all {len(todo)} month(s)")
@@ -297,6 +363,13 @@ def main() -> int:
         commit_message=f"+{len(written_cns - have):,} announcements, "
                        f"{len(manifest):,} total")
     print(f"\nPushed {len(written)} month(s) to {args.repo}")
+
+    if not args.keep_text:
+        cleared = prune_published_text(str(scraped), written_cns)
+        after = os.path.getsize(scraped) / 1e6
+        print(f"Dropped local text for {cleared:,} published postings; "
+              f"{scraped.name} is now {after:,.0f} MB")
+
     return 1 if refused else 0
 
 

--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+Publish the announcement dataset to HuggingFace.
+
+Joins two things this pipeline already has on disk:
+
+  data/historical_jobs_{year}.parquet  structured fields, from the historical
+                                       API — which needs no key and carries
+                                       closed postings, so it is the complete
+                                       list of what exists
+  data/scraped_jobs_{year}.parquet     announcement text, from the page — the
+                                       part no API gives well
+
+Output is one parquet per month plus a manifest, matching the layout the
+dataset already has. Columns are only ever added, so anything reading it keeps
+working.
+
+This replaces the publish path that lived in abigailhaddad/joa. Two reasons it
+moved. The dataset was missing `positionTitle` — the job title — because joa's
+field list never selected it, and nobody noticed since its controls CSV aliases
+announcementNumber as "title". And the eleven structured sections
+(qualificationSummary, majorDuties, ...) come from a parse that lives here, so
+publishing from here avoids a cross-repo dependency on it.
+
+    python publish_to_huggingface.py --dry-run
+    python publish_to_huggingface.py
+    python publish_to_huggingface.py --refresh-all   # rewrite every month
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import duckdb
+
+REPO_ID = os.environ.get("HF_DATASET_REPO", "abigailhaddad/usajobs-scraping")
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+BUILD_DIR = Path(__file__).resolve().parent.parent / "build" / "hf"
+
+# Structured fields, from the historical parquet.
+#
+# Against the field list this replaces, positionTitle and hiringSubelementName
+# are new — the published dataset had no job title in it at all.
+#
+# Not selected: usajobs_control_number (duplicates usajobsControlNumber);
+# HiringPaths / JobCategories / PositionLocations, which are empty integer
+# columns superseded by the *_1 varchars; inserted_at / last_seen, which are
+# bookkeeping for this pipeline's own collection runs.
+METADATA_FIELDS = """
+    h.usajobsControlNumber::varchar AS usajobsControlNumber,
+    h.positionTitle,
+    h.announcementNumber,
+    h.hiringAgencyCode, h.hiringAgencyName,
+    h.hiringDepartmentCode, h.hiringDepartmentName,
+    h.hiringSubelementName,
+    h.agencyLevel, h.agencyLevelSort,
+    h.appointmentType, h.workSchedule, h.serviceType, h.whoMayApply,
+    h.payScale, h.salaryType, h.minimumSalary, h.maximumSalary,
+    h.minimumGrade, h.maximumGrade, h.promotionPotential, h.supervisoryStatus,
+    h.totalOpenings, h.positionOpeningStatus,
+    h.announcementClosingTypeCode, h.announcementClosingTypeDescription,
+    substr(h.positionOpenDate, 1, 10)   AS positionOpenDate,
+    substr(h.positionCloseDate, 1, 10)  AS positionCloseDate,
+    substr(h.positionExpireDate, 1, 10) AS positionExpireDate,
+    h.travelRequirement, h.teleworkEligible, h.relocationExpensesReimbursed,
+    h.securityClearanceRequired, h.securityClearance, h.drugTestRequired,
+    h.disableApplyOnline, h.vendor,
+    h.hiringpaths_1        AS hiringPaths,
+    h.jobcategories_1      AS jobCategories,
+    h.positionlocations_1  AS positionLocations,
+    array_to_string(
+        regexp_extract_all(
+            coalesce(CAST(h.jobcategories_1 AS VARCHAR), ''), '[0-9]{4}'), ' | ')
+        AS occupationalSeries
+"""
+
+# The announcement body, from the page parse. The whole-page `text` stays for
+# anything already built against it; the sections are what make it usable
+# without re-parsing.
+TEXT_FIELDS = [
+    "jobSummary",
+    "majorDuties",
+    "requirements",
+    "conditionsOfEmployment",
+    "qualificationSummary",
+    "education",
+    "additionalInformation",
+    "benefits",
+    "howYouWillBeEvaluated",
+    "requiredDocuments",
+    "howToApply",
+    "text",
+]
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Publish the dataset to HuggingFace")
+    p.add_argument("--year", type=int,
+                   default=__import__("datetime").date.today().year)
+    p.add_argument("--repo", default=REPO_ID)
+    p.add_argument("--dry-run", action="store_true",
+                   help="Build locally and report; upload nothing")
+    p.add_argument("--refresh-all", action="store_true",
+                   help="Rewrite every month, not just the ones with new rows. "
+                        "Metadata keeps changing after a posting appears "
+                        "(close dates, opening status), so run this on a slower "
+                        "schedule than the daily top-up.")
+    p.add_argument("--data-dir", default=str(DATA_DIR))
+    return p.parse_args()
+
+
+def connection():
+    con = duckdb.connect()
+    con.execute("INSTALL httpfs; LOAD httpfs; SET http_retries=5;")
+    return con
+
+
+def select_sql(hist_path: str, scraped_path: str, month: str = None) -> str:
+    """The join. Scraped columns are coalesced against nothing — a posting with
+    no scraped row is excluded, because a row with no announcement text is what
+    the historical mirror already publishes."""
+    text_cols = ",\n    ".join(f"s.{c}" for c in TEXT_FIELDS)
+    where = ""
+    if month:
+        where = f"WHERE substr(h.positionOpenDate, 1, 7) = '{month}'"
+    return f"""
+        SELECT {METADATA_FIELDS},
+    {text_cols}
+        FROM read_parquet('{hist_path}') h
+        JOIN read_parquet('{scraped_path}') s
+          ON h.usajobsControlNumber::varchar = s.usajobs_control_number
+        {where}
+    """
+
+
+def month_of_every_posting(con, hist_path):
+    """Control number -> month, for the whole year, join or no join.
+
+    Needed to tell whether rebuilding a month would drop rows the dataset
+    already has: the manifest lists control numbers but not which month's file
+    holds them.
+    """
+    rows = con.execute(f"""
+        SELECT usajobsControlNumber::varchar AS cn,
+               substr(positionOpenDate, 1, 7) AS month
+        FROM read_parquet('{hist_path}')
+        WHERE positionOpenDate IS NOT NULL
+    """).fetchall()
+    return {cn: month for cn, month in rows}
+
+
+def available_months(con, hist_path, scraped_path):
+    """Month -> control numbers we could publish, computed without reading the
+    text columns. One varchar column per row, so it stays small even at the
+    scale of a full year."""
+    rows = con.execute(f"""
+        SELECT substr(h.positionOpenDate, 1, 7) AS month,
+               h.usajobsControlNumber::varchar AS cn
+        FROM read_parquet('{hist_path}') h
+        JOIN read_parquet('{scraped_path}') s
+          ON h.usajobsControlNumber::varchar = s.usajobs_control_number
+        WHERE h.positionOpenDate IS NOT NULL
+    """).fetchall()
+    months = {}
+    for month, cn in rows:
+        months.setdefault(month, set()).add(cn)
+    return months
+
+
+def partition_safe_months(todo, months, have, month_of):
+    """Split the months to rebuild into (safe, refused).
+
+    A month file is rewritten wholesale, so publishing one built from an
+    incomplete local join would delete announcements the dataset already has.
+    That is the normal state while the page backfill is still running, and it
+    is not recoverable from the dataset side, so refuse rather than shrink.
+
+    Returns refused entries as (month, would_drop, already_published).
+    """
+    safe, refused = [], []
+    for month in todo:
+        published_here = {cn for cn in have if month_of.get(cn) == month}
+        dropping = published_here - months.get(month, set())
+        if dropping:
+            refused.append((month, len(dropping), len(published_here)))
+        else:
+            safe.append(month)
+    return safe, refused
+
+
+def published_control_numbers(repo: str, token) -> set:
+    """What the dataset already holds. Downloads the manifest, a couple of MB,
+    rather than the dataset."""
+    from huggingface_hub import hf_hub_download
+    try:
+        path = hf_hub_download(repo, "manifest.csv", repo_type="dataset",
+                               token=token)
+    except Exception as e:
+        print(f"No manifest on {repo} ({e}) — treating the dataset as empty")
+        return set()
+    with open(path) as f:
+        next(f, None)  # header
+        return {line.strip() for line in f if line.strip()}
+
+
+def main() -> int:
+    args = parse_args()
+    data_dir = Path(args.data_dir)
+    hist = data_dir / f"historical_jobs_{args.year}.parquet"
+    scraped = data_dir / f"scraped_jobs_{args.year}.parquet"
+
+    for path in (hist, scraped):
+        if not path.exists():
+            print(f"Missing {path} — nothing to publish.")
+            return 0
+
+    token = os.environ.get("HF_TOKEN")
+    if not token and not args.dry_run:
+        print("HF_TOKEN is not set — nothing published.")
+        return 0
+
+    con = connection()
+    months = available_months(con, str(hist), str(scraped))
+    if not months:
+        print("No postings have both metadata and scraped text yet.")
+        return 0
+
+    have = published_control_numbers(args.repo, token)
+    print(f"Dataset holds {len(have):,} announcements")
+
+    total_available = sum(len(v) for v in months.values())
+    new = {cn for cns in months.values() for cn in cns} - have
+    print(f"Local join has {total_available:,}; {len(new):,} are new")
+
+    if args.refresh_all:
+        todo = sorted(months)
+        print(f"Refreshing all {len(todo)} month(s)")
+    else:
+        todo = sorted(m for m, cns in months.items() if cns - have)
+        print(f"{len(todo)} month(s) have new rows: {', '.join(todo) or '(none)'}")
+
+    month_of = month_of_every_posting(con, str(hist))
+    safe, refused = partition_safe_months(todo, months, have, month_of)
+
+    for month, n, total in refused:
+        print(f"  REFUSING {month}: rebuilding it would drop {n:,} of the "
+              f"{total:,} announcements already published for that month. "
+              f"The local scrape is missing them — run "
+              f"backfill_scraped_pages.py first.")
+    todo = safe
+
+    if not todo:
+        print("Nothing to publish")
+        return 1 if refused else 0
+
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    written = []
+    for month in todo:
+        name = f"data/{month.replace('-', '_')}.parquet"
+        dest = BUILD_DIR / name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        # COPY streams straight to disk. Materializing a month in Python would
+        # be ~800 MB of announcement text.
+        con.execute(f"""
+            COPY ({select_sql(str(hist), str(scraped), month)}
+                  ORDER BY usajobsControlNumber)
+            TO '{dest}' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 19);
+        """)
+        rows = con.execute(
+            f"SELECT count(*) FROM read_parquet('{dest}')").fetchone()[0]
+        print(f"  {name}: {rows:,} rows, {dest.stat().st_size/1e6:.1f} MB")
+        written.append(name)
+
+    # Only control numbers in months we actually wrote, plus whatever was
+    # already published. Adding one whose month was refused would claim the
+    # dataset holds a posting that is not in any file.
+    written_cns = {cn for m in todo for cn in months[m]}
+    manifest = sorted(have | written_cns)
+    (BUILD_DIR / "manifest.csv").write_text(
+        "usajobsControlNumber\n" + "\n".join(manifest) + "\n")
+
+    if args.dry_run:
+        print(f"\nDry run — {len(written)} file(s) built in {BUILD_DIR}, "
+              f"manifest would hold {len(manifest):,}")
+        return 0
+
+    # One commit for everything. File-by-file would mean a commit per month
+    # plus another for the manifest, leaving the dataset briefly inconsistent.
+    from huggingface_hub import CommitOperationAdd, HfApi
+    api = HfApi(token=token)
+    ops = [CommitOperationAdd(path_in_repo=n, path_or_fileobj=str(BUILD_DIR / n))
+           for n in written + ["manifest.csv"]]
+    api.create_commit(
+        repo_id=args.repo, repo_type="dataset", operations=ops,
+        commit_message=f"+{len(written_cns - have):,} announcements, "
+                       f"{len(manifest):,} total")
+    print(f"\nPushed {len(written)} month(s) to {args.repo}")
+    return 1 if refused else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_publish_hf.py
+++ b/scripts/tests/test_publish_hf.py
@@ -1,0 +1,96 @@
+"""Tests for publish_to_huggingface.py — the guard against shrinking a month.
+
+Month files are rewritten wholesale. Publishing one built from an incomplete
+local join deletes announcements the dataset already holds, and nothing on the
+dataset side can recover them. That is the normal state while
+backfill_scraped_pages.py is still running, which is exactly when a daily
+publish would otherwise fire.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from publish_to_huggingface import METADATA_FIELDS, TEXT_FIELDS, partition_safe_months
+
+
+class TestPartitionSafeMonths:
+    def test_a_month_gaining_rows_is_safe(self):
+        safe, refused = partition_safe_months(
+            todo=["2026-09"],
+            months={"2026-09": {"1", "2", "3"}},
+            have={"1", "2"},
+            month_of={"1": "2026-09", "2": "2026-09", "3": "2026-09"})
+        assert safe == ["2026-09"]
+        assert refused == []
+
+    def test_a_month_that_would_lose_rows_is_refused(self):
+        safe, refused = partition_safe_months(
+            todo=["2026-09"],
+            months={"2026-09": {"1", "9"}},          # local join lost "2"
+            have={"1", "2"},
+            month_of={"1": "2026-09", "2": "2026-09", "9": "2026-09"})
+        assert safe == []
+        assert refused == [("2026-09", 1, 2)]
+
+    def test_one_bad_month_does_not_block_a_good_one(self):
+        safe, refused = partition_safe_months(
+            todo=["2026-08", "2026-09"],
+            months={"2026-08": set(), "2026-09": {"3"}},
+            have={"1", "3"},
+            month_of={"1": "2026-08", "3": "2026-09"})
+        assert safe == ["2026-09"]
+        assert [m for m, *_ in refused] == ["2026-08"]
+
+    def test_published_rows_from_another_month_are_not_this_month_s_problem(self):
+        safe, refused = partition_safe_months(
+            todo=["2026-09"],
+            months={"2026-09": {"3"}},
+            have={"1", "3"},
+            month_of={"1": "2026-01", "3": "2026-09"})
+        assert safe == ["2026-09"]
+
+    def test_a_published_row_of_unknown_month_is_ignored(self):
+        # A control number the local metadata has never heard of -- a posting
+        # from another year, say -- cannot be attributed to this month, so it
+        # must not veto the rebuild.
+        safe, refused = partition_safe_months(
+            todo=["2026-09"],
+            months={"2026-09": {"3"}},
+            have={"unknown", "3"},
+            month_of={"3": "2026-09"})
+        assert safe == ["2026-09"]
+
+    def test_empty_dataset_publishes_everything(self):
+        safe, refused = partition_safe_months(
+            todo=["2026-01", "2026-02"],
+            months={"2026-01": {"1"}, "2026-02": {"2"}},
+            have=set(),
+            month_of={"1": "2026-01", "2": "2026-02"})
+        assert safe == ["2026-01", "2026-02"]
+        assert refused == []
+
+
+class TestPublishedSchema:
+    def test_the_job_title_is_selected(self):
+        # The field list this replaced omitted positionTitle, so the published
+        # dataset had no job title in it at all.
+        assert "h.positionTitle," in METADATA_FIELDS
+        assert "h.hiringSubelementName," in METADATA_FIELDS
+
+    def test_bookkeeping_columns_are_not_published(self):
+        for column in ("inserted_at", "last_seen", "usajobs_control_number"):
+            assert f"h.{column}" not in METADATA_FIELDS
+
+    def test_the_empty_integer_columns_are_not_published(self):
+        # HiringPaths / JobCategories / PositionLocations are empty integer
+        # columns in the mirror, superseded by the *_1 varchars.
+        assert "h.HiringPaths" not in METADATA_FIELDS
+        assert "h.hiringpaths_1" in METADATA_FIELDS
+
+    def test_every_announcement_section_is_published(self):
+        for section in ("jobSummary", "majorDuties", "qualificationSummary",
+                        "education", "requiredDocuments", "howToApply", "text"):
+            assert section in TEXT_FIELDS
+        assert len(TEXT_FIELDS) == 12

--- a/scripts/tests/test_publish_hf.py
+++ b/scripts/tests/test_publish_hf.py
@@ -12,7 +12,9 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-from publish_to_huggingface import METADATA_FIELDS, TEXT_FIELDS, partition_safe_months
+from publish_to_huggingface import (METADATA_FIELDS, TEXT_FIELDS,
+                                    partition_safe_months,
+                                    prune_published_text)
 
 
 class TestPartitionSafeMonths:
@@ -94,3 +96,71 @@ class TestPublishedSchema:
                         "education", "requiredDocuments", "howToApply", "text"):
             assert section in TEXT_FIELDS
         assert len(TEXT_FIELDS) == 12
+
+
+class TestPrunePublishedText:
+    """Announcement text is 97.8% of scraped_jobs_{year}.parquet — 5.42 KB of a
+    5.54 KB row, so a full year is 920 MB against 20 MB for everything else.
+    Once a posting is on HuggingFace the dataset is the store for its text, and
+    what stays local is the structured shadow the API comparison reads.
+    """
+
+    def _parquet(self, tmp_path, rows):
+        import pandas as pd
+        path = tmp_path / "scraped_jobs_2026.parquet"
+        pd.DataFrame(rows).to_parquet(path, index=False, compression="zstd")
+        return str(path)
+
+    def _rows(self):
+        return [
+            {"usajobs_control_number": "1", "positionTitle": "Analyst",
+             "minimumSalary": 50000.0, "text": "page one",
+             "qualificationSummary": "quals one", "majorDuties": "duties one"},
+            {"usajobs_control_number": "2", "positionTitle": "Engineer",
+             "minimumSalary": 90000.0, "text": "page two",
+             "qualificationSummary": "quals two", "majorDuties": "duties two"},
+        ]
+
+    def test_text_is_dropped_only_on_published_rows(self, tmp_path):
+        import pandas as pd
+        path = self._parquet(tmp_path, self._rows())
+        assert prune_published_text(path, {"1"}) == 1
+
+        out = pd.read_parquet(path).set_index("usajobs_control_number")
+        assert pd.isna(out.loc["1", "text"])
+        assert pd.isna(out.loc["1", "qualificationSummary"])
+        assert out.loc["2", "text"] == "page two"
+
+    def test_structured_columns_survive(self, tmp_path):
+        import pandas as pd
+        path = self._parquet(tmp_path, self._rows())
+        prune_published_text(path, {"1", "2"})
+        out = pd.read_parquet(path).set_index("usajobs_control_number")
+        assert out.loc["1", "positionTitle"] == "Analyst"
+        assert out.loc["2", "minimumSalary"] == 90000.0
+
+    def test_no_rows_are_lost(self, tmp_path):
+        import pandas as pd
+        path = self._parquet(tmp_path, self._rows())
+        prune_published_text(path, {"1", "2"})
+        assert len(pd.read_parquet(path)) == 2
+
+    def test_the_file_actually_shrinks(self, tmp_path):
+        path = self._parquet(tmp_path, self._rows())
+        before = os.path.getsize(path)
+        prune_published_text(path, {"1", "2"})
+        assert os.path.getsize(path) < before
+
+    def test_publishing_nothing_changes_nothing(self, tmp_path):
+        path = self._parquet(tmp_path, self._rows())
+        assert prune_published_text(path, set()) == 0
+
+    def test_a_missing_file_is_not_an_error(self, tmp_path):
+        assert prune_published_text(str(tmp_path / "absent.parquet"), {"1"}) == 0
+
+    def test_a_file_with_no_text_columns_is_left_alone(self, tmp_path):
+        import pandas as pd
+        path = self._parquet(tmp_path, [
+            {"usajobs_control_number": "1", "positionTitle": "Analyst"}])
+        assert prune_published_text(path, {"1"}) == 0
+        assert pd.read_parquet(path).loc[0, "positionTitle"] == "Analyst"

--- a/scripts/tests/test_scrape_parse.py
+++ b/scripts/tests/test_scrape_parse.py
@@ -19,7 +19,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from usajobs_scrape import (normalize_search_job, parse_job_page,
-                            parse_sections)
+                            parse_locations, parse_sections)
 
 FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
 
@@ -191,6 +191,88 @@ class TestLongTextSections:
         from bs4 import BeautifulSoup
         assert parse_sections(BeautifulSoup('<html><body>hi</body></html>',
                                             'html.parser')) == {}
+
+
+class TestLocations:
+    """Duty stations, emitted in the historical API's shape.
+
+    prep_web_data.py already reads a PositionLocations column of
+    {positionLocationCity, positionLocationState} dicts, so matching that shape
+    means the web build needs no changes to consume scraped locations.
+    """
+
+    def _soup(self, items):
+        from bs4 import BeautifulSoup
+        html = "".join(
+            f'<div class="location-item" data-location-text="{key}">'
+            f'<div class="font-bold">{label}</div></div>'
+            for key, label in items)
+        return BeautifulSoup(f"<html><body>{html}</body></html>", "html.parser")
+
+    def test_fixture_locations(self, open_job, closed_job):
+        assert json.loads(open_job['PositionLocations']) == [
+            {'positionLocationCity': 'Washington',
+             'positionLocationState': 'District of Columbia'}]
+        assert json.loads(closed_job['PositionLocations']) == [
+            {'positionLocationCity': 'Eielson AFB',
+             'positionLocationState': 'Alaska'}]
+
+    def test_state_abbreviation_is_expanded(self):
+        locs = parse_locations(self._soup([("anchorage, ak", "Anchorage, AK")]))
+        # The APIs write "Anchorage, Alaska"; the page writes "Anchorage, AK".
+        assert locs == [{'positionLocationCity': 'Anchorage',
+                         'positionLocationState': 'Alaska'}]
+
+    def test_overseas_region_is_left_alone(self):
+        locs = parse_locations(
+            self._soup([("sigonella sicily, italy", "Sigonella Sicily, Italy")]))
+        assert locs == [{'positionLocationCity': 'Sigonella Sicily',
+                         'positionLocationState': 'Italy'}]
+
+    def test_city_containing_a_comma_keeps_only_the_last_part_as_region(self):
+        locs = parse_locations(
+            self._soup([("x", "Winston-Salem, NC"), ("y", "Ft. Belvoir, VA")]))
+        assert [l['positionLocationCity'] for l in locs] == [
+            'Winston-Salem', 'Ft. Belvoir']
+
+    def test_page_renders_each_station_twice(self):
+        # One block for mobile, one for desktop. Every real page does this.
+        locs = parse_locations(self._soup([
+            ("denver, co (co1234) 1 main st", "Denver, CO"),
+            ("denver, co (co1234) 1 main st", "Denver, CO"),
+        ]))
+        assert len(locs) == 1
+
+    def test_two_offices_in_one_city_are_kept_apart(self):
+        # Deduping on the city/state line instead of data-location-text
+        # collapsed a real 408-station IRS posting to 361.
+        locs = parse_locations(self._soup([
+            ("denver, co (co1234) 1 main st", "Denver, CO"),
+            ("denver, co (co5678) 9 elm ave", "Denver, CO"),
+        ]))
+        assert len(locs) == 2
+        assert {l['positionLocationCity'] for l in locs} == {'Denver'}
+
+    def test_collapsed_label_with_no_comma_is_kept_whole(self):
+        # e.g. "Location Negotiable After Selection", or State's
+        # "Department of State Posts - Overseas and Domestic".
+        locs = parse_locations(self._soup([
+            ("location negotiable after selection",
+             "Location Negotiable After Selection")]))
+        assert locs == [{'positionLocationCity':
+                         'Location Negotiable After Selection'}]
+
+    def test_page_count_does_not_overwrite_the_search_count(self, open_job):
+        # Discovery stores the search endpoint's count, which matched the API
+        # on all 348 postings checked. The page's own count goes in its own
+        # field so a shortfall stays visible.
+        assert open_job['scrapedLocationCount'] == 1
+        assert 'positionLocationCount' not in open_job
+
+    def test_no_location_block(self):
+        from bs4 import BeautifulSoup
+        assert parse_locations(
+            BeautifulSoup('<html><body>hi</body></html>', 'html.parser')) == []
 
 
 class TestNormalizeSearchJob:

--- a/scripts/usajobs_scrape.py
+++ b/scripts/usajobs_scrape.py
@@ -368,6 +368,81 @@ def parse_sections(soup: BeautifulSoup) -> Dict[str, str]:
     return out
 
 
+# The announcement page writes duty stations as "City, ST"; both APIs use the
+# full state name ("Anchorage, Alaska"). Territories and the military postal
+# codes (AA/AE/AP) are in here because federal postings use all of them.
+_US_STATES = {
+    "AL": "Alabama", "AK": "Alaska", "AZ": "Arizona", "AR": "Arkansas",
+    "CA": "California", "CO": "Colorado", "CT": "Connecticut",
+    "DE": "Delaware", "DC": "District of Columbia", "FL": "Florida",
+    "GA": "Georgia", "HI": "Hawaii", "ID": "Idaho", "IL": "Illinois",
+    "IN": "Indiana", "IA": "Iowa", "KS": "Kansas", "KY": "Kentucky",
+    "LA": "Louisiana", "ME": "Maine", "MD": "Maryland",
+    "MA": "Massachusetts", "MI": "Michigan", "MN": "Minnesota",
+    "MS": "Mississippi", "MO": "Missouri", "MT": "Montana",
+    "NE": "Nebraska", "NV": "Nevada", "NH": "New Hampshire",
+    "NJ": "New Jersey", "NM": "New Mexico", "NY": "New York",
+    "NC": "North Carolina", "ND": "North Dakota", "OH": "Ohio",
+    "OK": "Oklahoma", "OR": "Oregon", "PA": "Pennsylvania",
+    "RI": "Rhode Island", "SC": "South Carolina", "SD": "South Dakota",
+    "TN": "Tennessee", "TX": "Texas", "UT": "Utah", "VT": "Vermont",
+    "VA": "Virginia", "WA": "Washington", "WV": "West Virginia",
+    "WI": "Wisconsin", "WY": "Wyoming",
+    "AS": "American Samoa", "FM": "Federated States of Micronesia",
+    "GU": "Guam", "MH": "Marshall Islands",
+    "MP": "Northern Mariana Islands", "PR": "Puerto Rico",
+    "PW": "Palau", "VI": "Virgin Islands",
+    "AA": "Armed Forces Americas", "AE": "Armed Forces Europe",
+    "AP": "Armed Forces Pacific",
+}
+
+
+def parse_locations(soup: BeautifulSoup) -> List[Dict[str, str]]:
+    """Duty stations, in the shape the historical API uses.
+
+    Each station is a .location-item whose bold line is "City, ST" for a US
+    posting and "City, Country" for an overseas one. The page renders every
+    item twice (one block for mobile, one for desktop), so entries are deduped
+    on data-location-text -- which carries the facility code and street address
+    and therefore separates two offices in the same city. Deduping on the
+    city/state line instead collapsed a 408-station IRS posting to 361.
+
+    Emitting positionLocationCity/positionLocationState means
+    prep_web_data.py's existing PositionLocations path handles this with no
+    changes: it renders "Anchorage, Alaska", the same string the API produces.
+    """
+    locations: List[Dict[str, str]] = []
+    seen = set()
+
+    for item in soup.select(".location-item"):
+        key = (item.get("data-location-text") or "").strip()
+        bold = item.select_one(".font-bold")
+        if not bold:
+            continue
+        label = _WS.sub(" ", bold.get_text(" ")).strip()
+        if not label:
+            continue
+
+        # No data-location-text to dedupe on: fall back to the label, which at
+        # worst merges two identical-looking stations.
+        if (key or label) in seen:
+            continue
+        seen.add(key or label)
+
+        city, _, region = label.rpartition(", ")
+        if not city:
+            # No comma at all -- a collapsed label such as "Department of
+            # State Posts - Overseas and Domestic". Keep it whole.
+            locations.append({"positionLocationCity": label})
+            continue
+
+        state = _US_STATES.get(region.upper(), region)
+        locations.append({"positionLocationCity": city,
+                          "positionLocationState": state})
+
+    return locations
+
+
 def parse_job_page(html: str) -> Dict:
     """A /job/{n} page -> the fields the API collection stores, plus the text.
 
@@ -489,6 +564,16 @@ def parse_job_page(html: str) -> Dict:
                  for h in paths_block.find_all("h3")]
         if paths:
             row["HiringPaths"] = json.dumps(paths)
+
+    # Deliberately does NOT set positionLocationCount. Discovery already put
+    # the search endpoint's count there, and for about 3% of postings the page
+    # lists fewer stations than the API holds -- a job with 31 API entries
+    # across 22 cities renders 12. Keeping both means the gap stays visible
+    # instead of being papered over.
+    locations = parse_locations(soup)
+    if locations:
+        row["PositionLocations"] = json.dumps(locations)
+        row["scrapedLocationCount"] = len(locations)
 
     row.update(parse_sections(soup))
     row["text"] = body_text


### PR DESCRIPTION
Four commits. The headline is a bug in the published dataset.

## The HuggingFace dataset had no job title

`joa/dataset.py`'s field list never selected `positionTitle`, so the dataset had no job title in it at all. It went unnoticed because that script's controls CSV aliases `announcementNumber` as `"title"`. `hiringSubelementName` was missing the same way.

It also carried only the flattened whole-page `text`, not the eleven structured announcement sections — those come from a parse that lives in this repo while the publish lived in another one.

So the publish moves here. `scripts/publish_to_huggingface.py` joins what's already on disk after a daily run: structured fields from `historical_jobs_{year}.parquet`, announcement text from `scraped_jobs_{year}.parquet`. Nothing is fetched at publish time.

| | columns |
|---|---:|
| Before | 40 |
| After | 53 |

New: `positionTitle`, `hiringSubelementName`, `jobSummary`, `majorDuties`, `requirements`, `conditionsOfEmployment`, `qualificationSummary`, `education`, `additionalInformation`, `benefits`, `howYouWillBeEvaluated`, `requiredDocuments`. The whole-page `text` stays, so anything built against the dataset keeps working.

**This also removes the workflow step that cloned joa.** That step rebuilds the months it touches from metadata plus `text` only, which would strip the section columns back off. It needs to be gone before the next scheduled run.

**Verified against the live dataset.** 2026-09 published and read back: 53 columns, `positionTitle` on 100% of 1,475 rows, every section populated. `education` at 88.3% and `benefits` at 99.9% are genuine absences.

## Storage: HuggingFace is the store, not the disk

Announcement text is **97.8%** of `scraped_jobs_{year}.parquet` — 5.42 KB of a 5.54 KB row. A full year would be 920 MB local.

After a month publishes, `prune_published_text` blanks those rows' text columns locally. What stays is the structured shadow the API comparison reads plus anything not yet pushed. Measured on real rows: **920 MB → 34 MB** for a 162,000-row year, no rows dropped, structured fields intact.

That's only safe because a rebuild reads text back from the month file already on HuggingFace, not from local disk. Local rows whose text was pruned are excluded on the local side so they can't win over the published copy.

## Guards

A month file is rewritten wholesale, so a publish built from an incomplete join would delete announcements the dataset holds, unrecoverably. `partition_safe_months` refuses those months by name and publishes the rest; the manifest only ever gains control numbers actually written. Verified both ways — it refused with an incomplete scrape, then published cleanly after the backfill filled the gap.

## Backfill

`scripts/backfill_scraped_pages.py` fills in postings from before the scrape existed — about 160k pages for 2026. It works a month at a time and publishes each as it lands, so the working set stays near one month instead of accumulating the year.

Profiled rather than guessed: a page costs 32 ms to parse, so a year is ~86 CPU-minutes over several hours. It's network-bound — an uncapped run measured **53% of one core**, not of the machine. It runs niced and under a CPU governor; `--max-cpu 15` held a measured run to 18% of a core at 3× the wall clock.

## Duty stations from the announcement page

Rendered through `prep_web_data.py`'s own `_extract_all_locations`, the scraped string matched the API exactly on **337 of 348** postings. The 11 that differ are the page showing less than the API holds — one posting has 31 API entries across 22 cities and renders 12. I checked the DOM; they aren't hidden.

Entries dedupe on `data-location-text`, not the visible city line: the page renders every station twice and the raw attribute carries the facility code and address that separate two offices in one city. Deduping on the visible line collapsed a 408-station IRS posting to 361; on the attribute it gives exactly 408. State abbreviations are expanded (`Anchorage, AK` → `Anchorage, Alaska`); `Sigonella Sicily, Italy` is left alone.

## Tests

119 passing, 28 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV