### PR TITLE
Fix the false-alarm health check (#569), and backfill the rest of the backlog in Actions

### DIFF
--- a/.github/workflows/backfill-pages.yml
+++ b/.github/workflows/backfill-pages.yml
@@ -1,0 +1,168 @@
+name: Backfill Announcement Pages
+
+# Fetches announcement pages for postings collected before the scrape existed
+# and publishes them to HuggingFace, one month per job.
+#
+# There are ~3.2M postings from 2017 on, which is roughly 81 hours of fetching
+# at the rate a single runner sustains. A month is ~30k pages, about 45
+# minutes, so it fits a job with room to spare and the work chunks naturally.
+#
+# Month jobs are stateless: --known-from-hf takes the already-done set from the
+# dataset's manifest rather than a shared parquet, so nothing is downloaded
+# from R2 beforehand or written back after, and jobs cannot race each other.
+# The only shared thing they touch is the HuggingFace dataset, and they touch
+# different months of it.
+#
+# Old pages are all still served — a sample across 2017, 2019, 2021, 2023 and
+# 2025 came back 40/40 alive with every section parsing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      years:
+        description: "Years to backfill, e.g. 2017 or 2017,2018 or 2019-2022"
+        type: string
+        required: true
+      workers:
+        description: "Concurrent page fetches per job"
+        type: string
+        default: "6"
+      skip_current_month:
+        description: "Leave the current month to the daily workflow"
+        type: boolean
+        default: true
+
+# One backfill at a time. A second dispatch queues rather than doubling the
+# load on usajobs.gov.
+concurrency:
+  group: usajobs-page-backfill
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+      count: ${{ steps.build.outputs.count }}
+    steps:
+      - name: Expand the year list into month jobs
+        id: build
+        env:
+          YEARS: ${{ inputs.years }}
+          SKIP_CURRENT: ${{ inputs.skip_current_month }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import datetime, json, os
+
+          years = set()
+          for part in os.environ["YEARS"].replace(" ", "").split(","):
+              if not part:
+                  continue
+              if "-" in part:
+                  lo, hi = part.split("-", 1)
+                  years.update(range(int(lo), int(hi) + 1))
+              else:
+                  years.add(int(part))
+
+          today = datetime.date.today()
+          skip_current = os.environ["SKIP_CURRENT"] == "true"
+          jobs = []
+          for year in sorted(years):
+              for month in range(1, 13):
+                  # Nothing exists past today, and the current month belongs to
+                  # the daily workflow -- both would publish the same file.
+                  if (year, month) > (today.year, today.month):
+                      continue
+                  if skip_current and (year, month) == (today.year, today.month):
+                      continue
+                  jobs.append({"year": year, "month": f"{year}-{month:02d}"})
+
+          print(f"matrix={json.dumps({'include': jobs})}")
+          print(f"count={len(jobs)}")
+          PY
+
+      - name: Report the plan
+        run: echo "Planned ${{ steps.build.outputs.count }} month job(s)"
+
+  backfill:
+    needs: plan
+    if: needs.plan.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 350  # a month is ~45 min; this is headroom, not a target
+    strategy:
+      fail-fast: false
+      # Deliberately low. Each job runs `workers` concurrent fetches, so this
+      # multiplies: 3 x 6 is 18 concurrent requests to usajobs.gov, against the
+      # 8 a daily run uses. Raising it is the fastest way to become a problem
+      # for the site.
+      max-parallel: 3
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests beautifulsoup4 pandas pyarrow duckdb tqdm \
+                      huggingface_hub python-dotenv
+
+      # Public R2, no credentials. Metadata only -- a few tens of MB.
+      - name: Fetch the historical mirror for ${{ matrix.year }}
+        run: |
+          mkdir -p data
+          curl -sSf -o "data/historical_jobs_${{ matrix.year }}.parquet" \
+            "https://pub-317c58882ec04f329b63842c1eb65b0c.r2.dev/data/historical_jobs_${{ matrix.year }}.parquet"
+          ls -lh "data/historical_jobs_${{ matrix.year }}.parquet"
+
+      - name: Check usajobs.gov serves this runner
+        run: |
+          python3 - <<'PY'
+          import sys
+          sys.path.insert(0, "scripts")
+          from usajobs_scrape import fetch_job_page, new_session, parse_job_page
+          html, err = fetch_job_page(new_session(), "721962100")
+          if not html:
+              sys.exit(f"usajobs.gov is not serving this runner: {err}")
+          row = parse_job_page(html)
+          missing = [f for f in ("jobSummary", "majorDuties", "qualificationSummary")
+                     if not row.get(f)]
+          if missing:
+              sys.exit(f"page parsed but these sections were empty: {missing}")
+          print("reachable, and the parse still works")
+          PY
+
+      - name: Backfill ${{ matrix.month }}
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python -u scripts/backfill_scraped_pages.py \
+            --year ${{ matrix.year }} \
+            --month ${{ matrix.month }} \
+            --known-from-hf \
+            --workers ${{ inputs.workers }} \
+            --max-cpu 0 \
+            --nice 0
+
+      - name: Section fill for ${{ matrix.month }}
+        if: always()
+        run: |
+          if [ -f logs/scrape_field_health.json ]; then
+            python3 -c "
+          import json
+          h = json.load(open('logs/scrape_field_health.json'))
+          print(f\"{h['pages_parsed']:,} pages parsed\")
+          for f, s in h['fields'].items():
+              print(f\"  {s['rate']:6.1%}  {f}\")
+          "
+          else
+            echo "No pages were parsed this job."
+          fi

--- a/README.md
+++ b/README.md
@@ -247,6 +247,27 @@ python scripts/backfill_scraped_pages.py --year 2026 --max-cpu 20   # gentler
 python scripts/backfill_scraped_pages.py --year 2026 --no-publish   # keep local
 ```
 
+2026 ran locally in 175 minutes for 160k pages: zero failures, zero 404s, 68.8
+CPU-minutes, and the local parquet ended at 15 MB because each month's text is
+pruned once published.
+
+### The rest of the backlog, in Actions
+
+There are ~3.2M postings from 2017 on — about 81 hours of fetching at the rate
+one runner sustains, so it does not belong in a single run. The
+**Backfill Announcement Pages** workflow chunks it one month per job, ~30k
+pages and ~45 minutes each. Dispatch it with a year, a list, or a range
+(`2017`, `2017,2018`, `2019-2022`).
+
+Month jobs are stateless. `--known-from-hf` takes the already-done set from the
+dataset's manifest instead of a shared parquet, so nothing is pulled from R2
+beforehand or written back after and jobs cannot race. `max-parallel` is
+deliberately 3: it multiplies with each job's `workers`, so 3 x 6 is already 18
+concurrent requests against the 8 a daily run uses.
+
+Old pages are all still served — a sample across 2017, 2019, 2021, 2023 and
+2025 came back 40/40 alive with every section parsing.
+
 ## Data Storage
 
 - **Cloudflare R2**: All parquet files are stored in R2 (not in this git repo due to size)

--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -301,6 +301,10 @@ def main() -> int:
         if not batch:
             return
         part += 1
+        # compact() removes the shard directory when it folds a month in, so
+        # the next month has to recreate it. Doing that here rather than once
+        # before the loop is what keeps a multi-month run alive.
+        os.makedirs(shards, exist_ok=True)
         path = os.path.join(shards, f"part-{run_id}-{part:05d}.parquet")
         pd.DataFrame(batch).to_parquet(path, index=False, compression="zstd")
         batch = []

--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -73,6 +73,11 @@ def parse_args():
     p.add_argument("--nice", type=int, default=10,
                    help="Process niceness, 0-19 (default 10). Higher yields "
                         "more readily to whatever else is running.")
+    p.add_argument("--known-from-hf", action="store_true",
+                   help="Take the already-scraped set from the HuggingFace "
+                        "manifest rather than the local parquet. That makes a "
+                        "run stateless, which is what lets month jobs run "
+                        "concurrently in CI without sharing a file.")
     p.add_argument("--month", help="Only this month (YYYY-MM). Useful for a "
                                    "pilot, or to resume a specific month.")
     p.add_argument("--no-publish", action="store_true",
@@ -137,6 +142,28 @@ def thread_session():
 
 def shard_dir(data_dir, year):
     return os.path.join(data_dir, f".scraped_shards_{year}")
+
+
+def published_control_numbers():
+    """What the HuggingFace dataset already holds, from its manifest.
+
+    A few MB rather than the dataset, and it is the same record the publisher
+    keys off. Using it instead of the local parquet is what makes a CI month
+    job stateless: nothing to download from R2 beforehand, nothing to write
+    back after, so jobs for different months cannot race each other.
+    """
+    import csv as _csv
+    from huggingface_hub import get_token, hf_hub_download
+    repo = os.environ.get("HF_DATASET_REPO", "abigailhaddad/usajobs-scraping")
+    token = os.environ.get("HF_TOKEN") or get_token()
+    try:
+        path = hf_hub_download(repo, "manifest.csv", repo_type="dataset",
+                               token=token)
+    except Exception as e:
+        print(f"  could not read the manifest ({e}) — treating it as empty")
+        return set()
+    with open(path) as f:
+        return {r[0] for r in _csv.reader(f) if r and r[0] != "usajobsControlNumber"}
 
 
 def stored_control_numbers(data_dir, year):
@@ -271,7 +298,11 @@ def main() -> int:
     if args.month:
         wanted = {cn: d for cn, d in wanted.items() if d[:7] == args.month}
         print(f"Restricted to {args.month}: {len(wanted):,} postings")
-    known = stored_control_numbers(args.data_dir, args.year)
+    if args.known_from_hf:
+        known = published_control_numbers()
+        print(f"HuggingFace manifest holds {len(known):,} announcements")
+    else:
+        known = stored_control_numbers(args.data_dir, args.year)
     todo = sorted(cn for cn in wanted if cn not in known)
 
     print(f"{args.year}: {len(wanted):,} postings in the historical mirror, "

--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -204,6 +204,31 @@ def compact(data_dir, year):
     return len(rows)
 
 
+def months_awaiting_publish(data_dir, year):
+    """Months whose local rows still hold announcement text.
+
+    Publishing prunes that text, so its presence is the marker for "fetched but
+    not yet on the dataset". Without this, a run killed between finishing a
+    month's pages and pushing them would strand it: the next run finds nothing
+    left to fetch for that month, so the fetch loop skips it and it is never
+    published.
+    """
+    import duckdb
+    hist = os.path.join(data_dir, f"historical_jobs_{year}.parquet")
+    scraped = os.path.join(data_dir, f"scraped_jobs_{year}.parquet")
+    if not (os.path.exists(hist) and os.path.exists(scraped)):
+        return []
+    rows = duckdb.connect().execute(f"""
+        SELECT DISTINCT substr(h.positionOpenDate, 1, 7) AS month
+        FROM read_parquet('{hist}') h
+        JOIN read_parquet('{scraped}') s
+          ON h.usajobsControlNumber::varchar = s.usajobs_control_number
+        WHERE s.text IS NOT NULL AND h.positionOpenDate IS NOT NULL
+        ORDER BY 1
+    """).fetchall()
+    return [r[0] for r in rows]
+
+
 def publish_month(data_dir, year, month):
     """Push one month to HuggingFace, which also drops its text from disk.
 
@@ -277,6 +302,16 @@ def main() -> int:
     if governor.target > 0:
         print(f"  holding CPU under {args.max_cpu:.0f}% of one core, "
               f"niceness +{args.nice}")
+
+    # Push anything a previous run fetched but did not get to publish, before
+    # spending hours on new pages. Only months with no work left, so a month
+    # that is about to be fetched is not published twice.
+    if not args.no_publish:
+        pending = [m for m in months_awaiting_publish(args.data_dir, args.year)
+                   if m not in {wanted[cn][:7] for cn in todo}]
+        for month in pending:
+            print(f"Publishing {month}, fetched by an earlier run")
+            publish_month(args.data_dir, args.year, month)
 
     # Work a month at a time and publish each one as it lands. Fetching the
     # whole year first would pile up 920 MB of announcement text on disk before

--- a/scripts/collect_scraped_data.py
+++ b/scripts/collect_scraped_data.py
@@ -31,6 +31,7 @@ number of announcements posted that day rather than the whole inventory.
 """
 
 import argparse
+import json
 import os
 import sys
 import threading
@@ -46,8 +47,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cap_alert import check_cap
 from collect_current_data import (get_year_from_date, group_jobs_by_year,
                                   load_existing_jobs, save_jobs_to_parquet)
-from usajobs_scrape import (MAX_RESULTS, fetch_job_page, new_session,
-                            normalize_search_job, open_inventory,
+from usajobs_scrape import (MAX_RESULTS, SECTION_FIELDS, fetch_job_page,
+                            new_session, normalize_search_job, open_inventory,
                             parse_job_page, search_slice)
 
 # Under this fraction of the inventory the facets promised, something in
@@ -56,6 +57,19 @@ COVERAGE_FLOOR = 0.97
 
 WARNING_FILE = os.path.join(os.path.dirname(__file__), "..", "logs",
                             "SCRAPE_COVERAGE_WARNING.txt")
+
+# Fill rates for the announcement sections, measured on the pages parsed this
+# run. It has to be measured here rather than by scanning the stored parquet:
+# publishing prunes the text of every posting it pushes, so a scan reports the
+# unpublished fraction and reads it as markup drift. That is exactly what
+# happened on 2026-09-04, when every field was flagged at 47.2% while live
+# pages were parsing at 12/12.
+HEALTH_FILE = os.path.join(os.path.dirname(__file__), "..", "logs",
+                           "scrape_field_health.json")
+
+# 'education' is genuinely absent from about one announcement in six.
+MIN_FILL = {"education": 0.50}
+MIN_FILL_DEFAULT = 0.90
 
 _local = threading.local()
 
@@ -218,7 +232,44 @@ def add_details(rows: List[Dict], known: set, workers: int,
           f"{len(failures)} failed, {len(gone)} already removed (404)")
     if failures:
         print("   Failed pages stay unstored and are retried on the next run")
+
+    parsed = [r for r in todo
+              if r["usajobs_control_number"] not in failures | gone]
+    record_field_health(parsed)
     return skipped | failures
+
+
+def record_field_health(parsed: List[Dict]) -> None:
+    """Fill rates for the announcement sections on the pages parsed this run.
+
+    This is the only check on whether the HTML parse still works — the API has
+    no counterpart for these fields — so it measures the freshly parsed rows,
+    which is the one population guaranteed not to have been pruned yet.
+    """
+    if not parsed:
+        return
+
+    stats = {}
+    for field in SECTION_FIELDS:
+        filled = sum(1 for r in parsed if r.get(field))
+        stats[field] = {"parsed": len(parsed), "filled": filled,
+                        "rate": filled / len(parsed)}
+
+    os.makedirs(os.path.dirname(HEALTH_FILE), exist_ok=True)
+    with open(HEALTH_FILE, "w") as f:
+        json.dump({"measured_at": datetime.now().isoformat(),
+                   "pages_parsed": len(parsed), "fields": stats}, f, indent=2)
+
+    print(f"Announcement section fill over {len(parsed):,} pages parsed:")
+    for field, st in stats.items():
+        floor = MIN_FILL.get(field, MIN_FILL_DEFAULT)
+        flag = "" if st["rate"] >= floor else "   BELOW FLOOR"
+        print(f"   {st['filled']:6,}/{st['parsed']:,}  {st['rate']:6.1%}  "
+              f"{field}{flag}")
+        if st["rate"] < floor:
+            warn(f"Announcement section '{field}' parsed out of only "
+                 f"{st['rate']:.1%} of {len(parsed):,} pages fetched this run; "
+                 f"floor is {floor:.0%}. The page markup has probably changed.")
 
 
 def main() -> None:

--- a/scripts/compare_scrape_to_api.py
+++ b/scripts/compare_scrape_to_api.py
@@ -22,6 +22,7 @@ which the daily workflow turns into a GitHub issue.
 """
 
 import argparse
+import json
 import os
 import sys
 from datetime import datetime
@@ -72,11 +73,10 @@ TEXT_FIELDS = [
     "text",
 ]
 
-# 'education' is genuinely absent from about one announcement in six, so the
-# floor has to sit below that; everything else measured at 100% on a 50-page
-# live sample (2026-09-02).
-MIN_TEXT_FILL = {"education": 0.50}
-MIN_TEXT_FILL_DEFAULT = 0.90
+# Written by collect_scraped_data.py, which measures fill on the pages it just
+# parsed and owns the threshold check.
+HEALTH_FILE = os.path.join(os.path.dirname(__file__), "..", "logs",
+                           "scrape_field_health.json")
 
 # Share of postings whose announcement page must list as many duty stations as
 # the search endpoint says the posting has. It is not 100%: for about 3% of
@@ -166,50 +166,23 @@ def compare_series(scraped: pd.Series, api: pd.Series) -> dict:
             "scrape_null": int(a.isna().sum()), "api_null": int(b.isna().sum())}
 
 
-def text_field_health(data_dir: str) -> list:
-    """Fill rate and median length for each long-text field.
+def text_field_health() -> dict:
+    """Section fill rates as collect_scraped_data.py measured them.
 
-    Scans the scraped parquets a row group at a time. These columns hold tens
-    of kilobytes per row, so reading a whole year of one into memory to
-    measure it would defeat the point.
+    Deliberately not computed by scanning scraped_jobs_*.parquet. Publishing
+    prunes the text of every posting it pushes, so a scan measures the
+    unpublished fraction and reads it as markup drift — which is what produced
+    issue #569, twelve fields flagged at 47.2% while live pages parsed at
+    12/12. The collector measures the pages it just parsed, and owns the
+    threshold check.
     """
-    import pyarrow.compute as pc
-    import pyarrow.parquet as pq
-
-    stats = {f: {"rows": 0, "filled": 0, "lengths": []} for f in TEXT_FIELDS}
-
-    for name in sorted(os.listdir(data_dir)):
-        if not (name.startswith("scraped_jobs_") and name.endswith(".parquet")):
-            continue
-        path = os.path.join(data_dir, name)
-        present = set(pq.read_schema(path).names)
-        for field in TEXT_FIELDS:
-            if field not in present:
-                stats[field]["rows"] += pq.read_metadata(path).num_rows
-                continue
-            for batch in pq.ParquetFile(path).iter_batches(
-                    batch_size=2000, columns=[field]):
-                column = batch.column(0)
-                lengths = pc.utf8_length(column)
-                stats[field]["rows"] += len(column)
-                filled = pc.greater(lengths, 0)
-                stats[field]["filled"] += int(
-                    pc.sum(pc.fill_null(filled, False)).as_py() or 0)
-                stats[field]["lengths"] += [
-                    v for v in lengths.to_pylist() if v]
-
-    rows = []
-    for field in TEXT_FIELDS:
-        st = stats[field]
-        lengths = sorted(st["lengths"])
-        rows.append({
-            "field": field,
-            "rows": st["rows"],
-            "filled": st["filled"],
-            "rate": st["filled"] / st["rows"] if st["rows"] else None,
-            "median": lengths[len(lengths) // 2] if lengths else 0,
-        })
-    return rows
+    if not os.path.exists(HEALTH_FILE):
+        return {}
+    try:
+        with open(HEALTH_FILE) as f:
+            return json.load(f)
+    except (ValueError, OSError):
+        return {}
 
 
 def location_completeness(data_dir: str) -> dict:
@@ -369,21 +342,18 @@ def main() -> int:
                  f"{1 - MIN_LOCATION_COMPLETE:.0%}. The location markup has "
                  f"probably changed.")
 
-    # The long-text sections, which the API has no counterpart for.
-    lines += ["## Announcement text (scraped only, no API counterpart)", "",
-              "| field | rows | filled | fill rate | median chars |",
-              "|---|---:|---:|---:|---:|"]
-    for row in text_field_health(args.data_dir):
-        rate = "—" if row["rate"] is None else f"{row['rate']:.1%}"
-        lines.append(f"| {row['field']} | {row['rows']:,} | {row['filled']:,} | "
-                     f"{rate} | {row['median']:,} |")
-
-        floor = MIN_TEXT_FILL.get(row["field"], MIN_TEXT_FILL_DEFAULT)
-        if row["rows"] >= 100 and row["rate"] is not None and row["rate"] < floor:
-            flag(f"Announcement text field '{row['field']}' is populated on "
-                 f"only {row['rate']:.1%} of {row['rows']:,} scraped postings; "
-                 f"floor is {floor:.0%}. The page markup has probably changed.")
-    lines.append("")
+    # The long-text sections, which the API has no counterpart for. Reported
+    # from what the collector measured while parsing; it raises the alarm.
+    health = text_field_health()
+    if health.get("fields"):
+        lines += [f"## Announcement text (scraped only, no API counterpart)", "",
+                  f"Measured on the {health['pages_parsed']:,} pages parsed at "
+                  f"{health['measured_at'][:19]}.", "",
+                  "| field | filled | fill rate |", "|---|---:|---:|"]
+        for field, st in health["fields"].items():
+            lines.append(f"| {field} | {st['filled']:,}/{st['parsed']:,} | "
+                         f"{st['rate']:.1%} |")
+        lines.append("")
 
     report = "\n".join(lines)
     print(report)

--- a/scripts/tests/test_scrape_health.py
+++ b/scripts/tests/test_scrape_health.py
@@ -1,0 +1,84 @@
+"""Tests for the announcement-section health check.
+
+Regression cover for issue #569. The check originally scanned
+scraped_jobs_{year}.parquet and treated a NULL text column as a parse failure.
+prune_published_text was added later and deliberately NULLs text on every
+posting it publishes, so the scan started measuring the unpublished fraction
+and reporting it as markup drift: on 2026-09-04 it flagged twelve fields at
+47.2% while live pages were parsing at 12/12.
+
+It now measures the pages parsed in the run, which is the one population that
+cannot have been pruned.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+import collect_scraped_data as csd
+from usajobs_scrape import SECTION_FIELDS
+
+
+@pytest.fixture(autouse=True)
+def isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(csd, "HEALTH_FILE", str(tmp_path / "health.json"))
+    monkeypatch.setattr(csd, "WARNING_FILE", str(tmp_path / "warning.txt"))
+    return tmp_path
+
+
+def row(**overrides):
+    r = {f: f"{f} content" for f in SECTION_FIELDS}
+    r.update(overrides)
+    return r
+
+
+def warnings(tmp_path):
+    path = tmp_path / "warning.txt"
+    return path.read_text() if path.exists() else ""
+
+
+def health(tmp_path):
+    return json.loads((tmp_path / "health.json").read_text())
+
+
+class TestRecordFieldHealth:
+    def test_fully_parsed_pages_raise_nothing(self, isolate):
+        csd.record_field_health([row() for _ in range(200)])
+        assert warnings(isolate) == ""
+        assert health(isolate)["fields"]["majorDuties"]["rate"] == 1.0
+
+    def test_a_section_that_stops_parsing_is_flagged(self, isolate):
+        rows = [row(majorDuties=None) for _ in range(100)]
+        csd.record_field_health(rows)
+        assert "majorDuties" in warnings(isolate)
+        assert "markup has probably changed" in warnings(isolate)
+
+    def test_education_has_a_lower_floor(self, isolate):
+        # Genuinely absent from roughly one announcement in six, so 80% fill
+        # must not raise while the same rate would for any other field.
+        rows = [row(education=None if i % 5 == 0 else "x") for i in range(100)]
+        csd.record_field_health(rows)
+        assert "education" not in warnings(isolate)
+
+    def test_education_still_flags_when_it_truly_breaks(self, isolate):
+        csd.record_field_health([row(education=None) for _ in range(100)])
+        assert "education" in warnings(isolate)
+
+    def test_pruned_rows_cannot_affect_the_measurement(self, isolate):
+        # The bug: published rows have their text nulled on disk. Those rows
+        # are not in the parsed list, so they cannot drag the rate down.
+        parsed = [row() for _ in range(50)]
+        csd.record_field_health(parsed)
+        assert warnings(isolate) == ""
+        assert health(isolate)["pages_parsed"] == 50
+
+    def test_a_run_that_parsed_nothing_writes_nothing(self, isolate):
+        csd.record_field_health([])
+        assert not os.path.exists(csd.HEALTH_FILE)
+        assert warnings(isolate) == ""
+
+    def test_every_parser_section_is_measured(self, isolate):
+        csd.record_field_health([row()])
+        assert set(health(isolate)["fields"]) == set(SECTION_FIELDS)

--- a/scripts/usajobs_scrape.py
+++ b/scripts/usajobs_scrape.py
@@ -318,6 +318,15 @@ def _clean(node) -> str:
     return _WS.sub(" ", node.get_text(" ")).strip()
 
 
+# Everything parse_job_page produces from the announcement body. Health checks
+# key off this: if usajobs.gov changes its markup, these stop being populated.
+SECTION_FIELDS = [
+    "jobSummary", "majorDuties", "requirements", "conditionsOfEmployment",
+    "qualificationSummary", "education", "additionalInformation", "benefits",
+    "howYouWillBeEvaluated", "requiredDocuments", "howToApply", "text",
+]
+
+
 def parse_sections(soup: BeautifulSoup) -> Dict[str, str]:
     """The long-text fields, keyed by the name the row will carry."""
     out: Dict[str, str] = {}


### PR DESCRIPTION
Four commits: two fixes found by running the 2026 backfill for real, the #569 false alarm, and the workflow for the remaining ~3.05M postings.

## #569 was my bug, not a markup change

The overnight run opened [#569](https://github.com/abigailhaddad/usajobs_historical/issues/569) — twelve fields flagged at 47.2%, "the page markup has probably changed."

It hadn't. Live pages that morning parsed at **12/12 on every section**.

`text_field_health()` scanned `scraped_jobs_{year}.parquet` and treated a NULL text column as a parse failure. `prune_published_text` was added *afterwards* and deliberately NULLs text on every posting it publishes — so the check started measuring the unpublished fraction and reporting it as drift. 47.2% was the share of rows not yet pushed.

The fix measures fill over the pages parsed in the run, the one population that cannot have been pruned. `collect_scraped_data.py` writes `logs/scrape_field_health.json` and owns the threshold check; the comparison renders it instead of scanning. The parser's output contract moves to `SECTION_FIELDS` so the check and the publisher can't drift apart again.

Verified: a live 40-page run reports 100% on every section, 92.5% on education, and raises nothing. Seven regression tests cover it, including the specific case where pruned rows must not affect the measurement.

## Two fixes the real run found

**Shard directory.** `compact()` removes it when folding a month in, but it was created once before the month loop — so January worked and February died on its first write. Creating it in `flush()` fixes it however many times compact clears it.

**Stranded months.** A run killed between finishing a month's pages and pushing them stranded that month permanently: the next run finds nothing left to fetch, so the loop skips it and it never publishes. Hit for real on 2026-03, with all 23,121 pages stored locally while the dataset held its 40-column version. The marker needed no new state — publishing prunes a month's text, so text still present means fetched-but-not-published.

## The rest of the backlog

~3.2M postings from 2017 on, roughly 81 hours of fetching at the rate one runner sustains. The **Backfill Announcement Pages** workflow chunks it one month per job — ~30k pages, ~45 minutes — well inside a job's limit. Dispatch with a year, list, or range (`2017`, `2017,2018`, `2019-2022`); the planner expands `2017-2026` to 116 jobs, inside GitHub's 256 cap.

Month jobs are **stateless**, which is what makes them safe to run concurrently. `--known-from-hf` takes the already-done set from the dataset's manifest rather than a shared parquet, so a job pulls nothing from R2 beforehand and writes nothing back after. The current month is excluded by default since the daily workflow publishes it.

`max-parallel` is 3 deliberately — it multiplies with each job's workers, so 3 × 6 is already 18 concurrent requests against the 8 a daily run uses.

**Checked before building any of it:** pages from 2017 on are all still served. A sample across 2017, 2019, 2021, 2023 and 2025 came back **40/40 alive** with every checked section parsing. Each job also re-verifies reachability *and* that the parse still yields sections before fetching a month, so a markup change fails fast instead of writing 30k rows of nulls.

## 2026 is already done

173,523 announcements across nine months, every month matching the historical mirror exactly. Zero failures and zero 404s across the whole 160k-page crawl. The local parquet ended at **15 MB** — text pruned per month as it published — against the 920 MB it would otherwise hold.

## Tests

126 passing, 7 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV