### PR TITLE
Judge a month rebuild against the existing file, not the manifest

### DIFF
--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -276,19 +276,34 @@ def available_months(con, hist_path, scraped_path):
     return months
 
 
-def partition_safe_months(todo, months, have, month_of):
+def partition_safe_months(todo, months, have, month_of, priors=None):
     """Split the months to rebuild into (safe, refused).
 
     A month file is rewritten wholesale, so publishing one built from an
-    incomplete local join would delete announcements the dataset already has.
-    That is the normal state while the page backfill is still running, and it
-    is not recoverable from the dataset side, so refuse rather than shrink.
+    incomplete local join would delete announcements the dataset already has,
+    unrecoverably. The test is whether the rebuild would contain everything the
+    existing file contains.
+
+    The existing file is the authority for that, not the manifest. Which month
+    file a posting lives in was fixed by its open date at publish time, while
+    the manifest cross-referenced against *current* metadata says where it
+    would go today — and those differ, because the daily collection refreshes
+    the last 14 days and open dates shift. On 2026-09-04 that mismatch refused
+    2026-09 over 4 postings that were sitting safely in another month's file.
+
+    Only when there is no prior file to compare against — the download failed,
+    or the month has never been published — does it fall back to the manifest.
 
     Returns refused entries as (month, would_drop, already_published).
     """
+    priors = priors or {}
     safe, refused = [], []
     for month in todo:
-        published_here = {cn for cn in have if month_of.get(cn) == month}
+        prior_cns = priors.get(month)
+        if prior_cns is None:
+            published_here = {cn for cn in have if month_of.get(cn) == month}
+        else:
+            published_here = prior_cns
         dropping = published_here - months.get(month, set())
         if dropping:
             refused.append((month, len(dropping), len(published_here)))
@@ -359,7 +374,7 @@ def main() -> int:
     # Pull the month files we are about to rewrite. Their text is the source
     # for every posting whose local copy has been pruned, and their control
     # numbers are what makes the rebuild provably non-destructive.
-    priors, availability = {}, {}
+    priors, availability, prior_sets = {}, {}, {}
     for month in todo:
         prior = download_month(args.repo, month, token) if token else None
         priors[month] = prior
@@ -370,10 +385,12 @@ def main() -> int:
                 f"FROM read_parquet('{prior}')").fetchall()}
             print(f"  {month}: {len(prior_cns):,} already published, "
                   f"{len(months[month] - prior_cns):,} new")
+            prior_sets[month] = prior_cns
         availability[month] = months[month] | prior_cns
 
     month_of = month_of_every_posting(con, str(hist))
-    safe, refused = partition_safe_months(todo, availability, have, month_of)
+    safe, refused = partition_safe_months(todo, availability, have, month_of,
+                                          prior_sets)
 
     for month, n, total in refused:
         print(f"  REFUSING {month}: rebuilding it would drop {n:,} of the "

--- a/scripts/tests/test_publish_hf.py
+++ b/scripts/tests/test_publish_hf.py
@@ -74,6 +74,63 @@ class TestPartitionSafeMonths:
         assert refused == []
 
 
+class TestGuardUsesTheExistingFile:
+    """Regression for the 2026-09-04 refusal.
+
+    The guard read the manifest cross-referenced against current metadata to
+    decide what a month already holds. Which file a posting actually lives in
+    was fixed by its open date at publish time, and the daily collection
+    refreshes the last 14 days, so open dates shift and the two disagree. That
+    refused 2026-09 over 4 postings sitting safely in another month's file, and
+    blocked the daily publish.
+    """
+
+    def test_the_prior_file_beats_the_manifest(self):
+        # "4" is in the manifest and maps to this month by today's metadata,
+        # but is not in the month file, so it is not this month's to lose.
+        safe, refused = partition_safe_months(
+            todo=["2026-09"],
+            months={"2026-09": {"1", "2", "3"}},
+            have={"1", "2", "3", "4"},
+            month_of={c: "2026-09" for c in "1234"},
+            priors={"2026-09": {"1", "2", "3"}})
+        assert safe == ["2026-09"]
+        assert refused == []
+
+    def test_a_genuine_shrink_is_still_refused(self):
+        # "3" IS in the month file and would not survive the rebuild.
+        safe, refused = partition_safe_months(
+            todo=["2026-09"],
+            months={"2026-09": {"1", "2"}},
+            have={"1", "2", "3"},
+            month_of={c: "2026-09" for c in "123"},
+            priors={"2026-09": {"1", "2", "3"}})
+        assert safe == []
+        assert refused == [("2026-09", 1, 3)]
+
+    def test_no_prior_file_falls_back_to_the_manifest(self):
+        # Download failed or the month was never published: the manifest is
+        # all there is, so keep the conservative check.
+        safe, refused = partition_safe_months(
+            todo=["2026-09"],
+            months={"2026-09": {"1"}},
+            have={"1", "2"},
+            month_of={c: "2026-09" for c in "12"},
+            priors={})
+        assert safe == []
+        assert [m for m, *_ in refused] == ["2026-09"]
+
+    def test_an_empty_prior_is_not_the_same_as_a_missing_one(self):
+        # A month file that exists and is empty cannot lose anything.
+        safe, refused = partition_safe_months(
+            todo=["2026-09"],
+            months={"2026-09": {"1"}},
+            have={"1", "2"},
+            month_of={c: "2026-09" for c in "12"},
+            priors={"2026-09": set()})
+        assert safe == ["2026-09"]
+
+
 class TestPublishedSchema:
     def test_the_job_title_is_selected(self):
         # The field list this replaced omitted positionTitle, so the published


### PR DESCRIPTION
The first daily run after the new publisher went live refused to publish:

```
REFUSING 2026-09: rebuilding it would drop 4 of the 1,504 announcements
already published for that month.
```

Nothing was at risk, and left alone this blocks the daily publish **indefinitely** — every run would refuse the current month, and the refusal doesn't self-clear.

## What was wrong

The guard decided what a month already holds by taking manifest entries and mapping them to a month using *current* metadata. But which file a posting actually lives in was fixed by its open date *at publish time*, and the daily collection re-collects the last 14 days — so open dates shift and the two disagree. Those 4 postings were sitting safely in another month's file.

## The fix

The existing month file is the authority for what that file holds, so the guard compares against its contents instead.

Since text is already merged back from that same file, a month can no longer shrink — which is precisely the property the guard existed to enforce, now enforced by construction rather than by a check that could disagree with reality.

The manifest check stays as the fallback for when there's no prior file: the download failed, or the month has never been published. An empty prior file is deliberately distinguished from a missing one — it exists and holds nothing, so it can't lose anything.

## Everything else in that run worked

| | |
|---|---|
| Discovered | 14,066 — exactly the facet count |
| Pages fetched | 586 in 0.9 min, 0 failed, 0 404s |
| Coverage vs API | **100%**, 0 API-only |
| Section health tripwire | did not fire (the #569 fix holding) |

The incremental path is doing what it should: 586 new pages rather than the full 14,066 inventory.

## Tests

130 passing, 4 new covering this specific case — including that a genuine shrink is still refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV