### PR TITLE
Manage a worker box from the repo, and run the backlog on it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ questionnaires/session_base64.txt
 # HuggingFace publish staging and page-backfill shards
 build/
 data/.scraped_shards_*/
+
+# Hetzner API token for deploy/server.sh
+deploy/.hcloud.env

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,72 @@
+# Running long jobs on a box instead of Actions
+
+GitHub's free runners queue. On 2026-09-04 a 12-job backfill spent 4h33m
+waiting and 5h working — just over half the wall clock was queue. The daily
+pipeline is small and belongs in Actions; bulk backfills do not.
+
+This directory manages a worker box from the repo. The Hetzner console is
+needed exactly once, to make a project and an API token.
+
+## Setup
+
+**Once, in the console:** create a project, then Security → API tokens →
+Generate with read/write. Put it in `deploy/.hcloud.env` (gitignored):
+
+```
+HCLOUD_TOKEN=...
+```
+
+**Once, on your laptop:** install the CLI (`brew install hcloud`) and register
+your SSH key if you have not:
+
+```bash
+hcloud ssh-key create --name laptop --public-key-from-file ~/.ssh/id_ed25519.pub
+```
+
+**Then:**
+
+```bash
+./deploy/server.sh create      # create + bootstrap
+ssh root@$IP "printf 'HF_TOKEN=%s\n' YOUR_TOKEN > /etc/usajobs-backfill.env"
+ssh root@$IP 'bash -s' < deploy/install-backfill.sh
+```
+
+## Day to day
+
+```bash
+./deploy/server.sh status    # what exists
+./deploy/server.sh logs      # follow the job
+./deploy/server.sh ssh       # shell
+./deploy/server.sh destroy   # stop paying
+```
+
+## Cost
+
+`cx32` (4 vCPU, 8 GB) is around €7–8/month, **billed hourly**. The backlog is
+about four days of work, so running it and destroying the box costs roughly a
+euro or two. The monthly figure is a cap, not a commitment — check the exact
+price in the create form, and destroy the server when the work is done.
+
+8 GB rather than 4 because `compact()` concatenates a month's shards in pandas
+and peaks near 1.6 GB.
+
+## Rate
+
+`run-backfill.sh` uses 6 concurrent fetches — about 8–9 pages/sec, so
+2018–2025 (~2.9M pages) takes roughly four days. usajobs.gov has served
+300k+ pages at this rate with zero failures and zero 404s. Raising
+`BACKFILL_WORKERS` is a decision about load on their servers, not about the
+box.
+
+## Resumability
+
+Nothing here needs babysitting. `--known-from-hf` asks the dataset what is
+already published, so a restart continues rather than redoing work, and within
+a month pages land in shards that fold in at the end. A crash or reboot costs
+at most one month's partial fetch. The unit restarts on failure.
+
+## Adding another repo
+
+`hetzner-bootstrap.sh` is generic — a worker user, `/srv/repos`, a venv per
+checkout. `install-backfill.sh` is the per-repo half and is meant to be copied:
+change `REPO_URL`, the pip line, and the unit body.

--- a/deploy/hetzner-bootstrap.sh
+++ b/deploy/hetzner-bootstrap.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# One-time setup for a Hetzner (or any Ubuntu 24.04) box that runs long jobs
+# for this and other repos.
+#
+# Deliberately generic: it makes a worker user, a place for checkouts, and a
+# per-repo virtualenv. Nothing here is specific to the USAJOBS backfill --
+# that is deploy/usajobs-backfill.service, which is the pattern to copy for
+# the next repo.
+#
+#   ssh root@YOUR_SERVER_IP 'bash -s' < deploy/hetzner-bootstrap.sh
+#
+# Idempotent. Safe to rerun.
+
+set -euo pipefail
+
+WORKER=worker
+REPOS=/srv/repos
+
+echo "==> packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq \
+  python3 python3-venv python3-pip git tmux curl ca-certificates \
+  ufw unattended-upgrades >/dev/null
+
+echo "==> firewall (ssh only; nothing here listens)"
+ufw --force reset >/dev/null
+ufw default deny incoming >/dev/null
+ufw default allow outgoing >/dev/null
+ufw allow OpenSSH >/dev/null
+ufw --force enable >/dev/null
+
+echo "==> unattended security updates"
+dpkg-reconfigure -f noninteractive unattended-upgrades >/dev/null 2>&1 || true
+
+echo "==> worker user and $REPOS"
+id -u "$WORKER" >/dev/null 2>&1 || useradd --create-home --shell /bin/bash "$WORKER"
+mkdir -p "$REPOS"
+chown -R "$WORKER:$WORKER" "$REPOS"
+
+# Root's authorized_keys came from the Hetzner create form; give the worker the
+# same access so you can ssh in as worker instead of root.
+if [ -f /root/.ssh/authorized_keys ]; then
+  install -d -m 700 -o "$WORKER" -g "$WORKER" "/home/$WORKER/.ssh"
+  install -m 600 -o "$WORKER" -g "$WORKER" \
+    /root/.ssh/authorized_keys "/home/$WORKER/.ssh/authorized_keys"
+fi
+
+echo
+echo "Done. Next:"
+echo "  1. Put your HuggingFace token on the box:"
+echo "       printf 'HF_TOKEN=hf_xxx\\n' > /etc/usajobs-backfill.env"
+echo "       chmod 600 /etc/usajobs-backfill.env"
+echo "  2. bash -s < deploy/install-backfill.sh   (checkout, venv, systemd unit)"

--- a/deploy/install-backfill.sh
+++ b/deploy/install-backfill.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Check out the repo, build its venv, install the systemd unit, start it.
+#
+# This is the per-repo half; hetzner-bootstrap.sh is the generic half. Copy
+# this file as the template for the next repo you move onto the box: the only
+# repo-specific parts are REPO_URL, the pip line, and the unit.
+#
+#   ssh root@YOUR_SERVER_IP 'bash -s' < deploy/install-backfill.sh
+#
+# Idempotent. Rerunning updates the checkout and restarts the job.
+
+set -euo pipefail
+
+WORKER=worker
+REPOS=/srv/repos
+NAME=usajobs_historical
+REPO_URL=https://github.com/abigailhaddad/usajobs_historical
+DIR="$REPOS/$NAME"
+
+[ -s /etc/usajobs-backfill.env ] || {
+  echo "Missing /etc/usajobs-backfill.env with HF_TOKEN=..."
+  echo "  printf 'HF_TOKEN=hf_xxx\n' > /etc/usajobs-backfill.env"
+  echo "  chmod 600 /etc/usajobs-backfill.env"
+  exit 1; }
+chmod 600 /etc/usajobs-backfill.env
+
+echo "==> checkout"
+if [ -d "$DIR/.git" ]; then
+  sudo -u "$WORKER" git -C "$DIR" fetch --quiet origin
+  sudo -u "$WORKER" git -C "$DIR" reset --hard --quiet origin/main
+else
+  sudo -u "$WORKER" git clone --quiet "$REPO_URL" "$DIR"
+fi
+
+echo "==> venv"
+sudo -u "$WORKER" python3 -m venv "$DIR/.venv"
+sudo -u "$WORKER" "$DIR/.venv/bin/pip" install --quiet --upgrade pip
+sudo -u "$WORKER" "$DIR/.venv/bin/pip" install --quiet \
+  requests beautifulsoup4 pandas pyarrow duckdb tqdm huggingface_hub python-dotenv
+
+echo "==> systemd unit"
+cat > /etc/systemd/system/usajobs-backfill.service <<UNIT
+[Unit]
+Description=USAJOBS announcement-page backfill
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=$WORKER
+WorkingDirectory=$DIR
+EnvironmentFile=/etc/usajobs-backfill.env
+ExecStart=$DIR/deploy/run-backfill.sh
+# Every step is resumable, so restarting after a crash re-reads what is
+# already published and continues rather than redoing work.
+Restart=on-failure
+RestartSec=120
+TimeoutStartSec=infinity
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now usajobs-backfill.service
+
+echo
+echo "Started. Watch it with:"
+echo "  journalctl -u usajobs-backfill -f"
+echo "or from your laptop:  ./deploy/server.sh logs"

--- a/deploy/run-backfill.sh
+++ b/deploy/run-backfill.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Walk the backlog year by year. Started by usajobs-backfill.service.
+#
+# Deliberately gentle: 6 concurrent fetches, which measured ~8-9 pages/sec, so
+# 2018-2025 (~2.9M pages) takes about four days. usajobs.gov has served
+# 300k+ pages at this rate with zero failures and zero 404s. Going faster is a
+# decision about load on their servers, not about the box.
+#
+# Every step is resumable, so a crash or reboot costs at most one month's
+# partial fetch: --known-from-hf asks the dataset what is already published,
+# and within a month, pages land in shards that fold in at the end.
+
+set -uo pipefail
+
+YEARS="${BACKFILL_YEARS:-2018 2019 2020 2021 2022 2023 2024 2025}"
+WORKERS="${BACKFILL_WORKERS:-6}"
+REPO="${REPO_DIR:-/srv/repos/usajobs_historical}"
+MIRROR="https://pub-317c58882ec04f329b63842c1eb65b0c.r2.dev/data"
+
+cd "$REPO"
+mkdir -p data logs
+
+for year in $YEARS; do
+  echo "=== $year ==="
+
+  # Metadata only, a few tens of MB, and public -- no R2 credentials anywhere.
+  if [ ! -s "data/historical_jobs_${year}.parquet" ]; then
+    echo "--- fetching the historical mirror for $year"
+    curl -sSf --retry 5 --retry-delay 10 \
+      -o "data/historical_jobs_${year}.parquet" \
+      "$MIRROR/historical_jobs_${year}.parquet" || {
+        echo "!!! could not fetch the mirror for $year; skipping"; continue; }
+  fi
+
+  ./.venv/bin/python -u scripts/backfill_scraped_pages.py \
+      --year "$year" \
+      --known-from-hf \
+      --workers "$WORKERS" \
+      --max-cpu 0 \
+      --nice 0
+  status=$?
+  echo "--- $year exited $status"
+
+  # The year's text is on HuggingFace now and pruned locally; the mirror copy
+  # is the only thing worth reclaiming.
+  rm -f "data/historical_jobs_${year}.parquet"
+done
+
+echo "=== all years done ==="

--- a/deploy/server.sh
+++ b/deploy/server.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Manage the worker box from the repo instead of the Hetzner console.
+#
+# The console is needed exactly once: make a project and an API token
+# (Security > API tokens > Generate, read/write). Everything after that is
+# here.
+#
+#   export HCLOUD_TOKEN=...            # or put it in deploy/.hcloud.env
+#   ./deploy/server.sh create          # make the box and provision it
+#   ./deploy/server.sh status          # what exists, and what it costs
+#   ./deploy/server.sh logs            # follow the backfill
+#   ./deploy/server.sh ssh             # shell on it
+#   ./deploy/server.sh destroy         # stop paying for it
+#
+# Billing is hourly with a monthly cap, so a job that runs four days costs
+# roughly a seventh of the monthly price. Destroy it when the work is done.
+
+set -euo pipefail
+
+NAME="${WORKER_NAME:-usajobs-worker}"
+TYPE="${WORKER_TYPE:-cx32}"          # 4 vCPU / 8 GB — the compact step peaks ~1.6 GB
+IMAGE="${WORKER_IMAGE:-ubuntu-24.04}"
+LOCATION="${WORKER_LOCATION:-nbg1}"  # override if a location is out of stock
+SSH_KEY_NAME="${WORKER_SSH_KEY:-}"   # name of the key as hcloud knows it
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$HERE/.hcloud.env" ] && . "$HERE/.hcloud.env"
+
+need() { command -v "$1" >/dev/null || { echo "missing: $1"; exit 1; }; }
+
+hc() {
+  need hcloud
+  : "${HCLOUD_TOKEN:?set HCLOUD_TOKEN, or put it in deploy/.hcloud.env}"
+  hcloud "$@"
+}
+
+server_ip() { hc server ip "$NAME" 2>/dev/null; }
+
+cmd_create() {
+  if server_ip >/dev/null 2>&1; then
+    echo "$NAME already exists at $(server_ip)"
+  else
+    if [ -z "$SSH_KEY_NAME" ]; then
+      SSH_KEY_NAME=$(hc ssh-key list -o noheader -o columns=name | head -1)
+      [ -n "$SSH_KEY_NAME" ] || {
+        echo "No SSH key registered. Add one first:"
+        echo "  hcloud ssh-key create --name laptop --public-key-from-file ~/.ssh/id_ed25519.pub"
+        exit 1; }
+      echo "using ssh key: $SSH_KEY_NAME"
+    fi
+    echo "==> creating $NAME ($TYPE, $IMAGE, $LOCATION)"
+    hc server create --name "$NAME" --type "$TYPE" --image "$IMAGE" \
+      --location "$LOCATION" --ssh-key "$SSH_KEY_NAME"
+  fi
+  cmd_provision
+}
+
+cmd_provision() {
+  local ip; ip=$(server_ip)
+  echo "==> waiting for ssh on $ip"
+  for _ in $(seq 1 60); do
+    ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 \
+        "root@$ip" true 2>/dev/null && break
+    sleep 5
+  done
+  echo "==> bootstrap"
+  ssh "root@$ip" 'bash -s' < "$HERE/hetzner-bootstrap.sh"
+  echo
+  echo "Now put the HuggingFace token on the box, then install the job:"
+  echo "  ssh root@$ip \"printf 'HF_TOKEN=%s\\n' YOUR_TOKEN > /etc/usajobs-backfill.env && chmod 600 /etc/usajobs-backfill.env\""
+  echo "  ssh root@$ip 'bash -s' < $HERE/install-backfill.sh"
+}
+
+cmd_status() {
+  hc server list -o columns=name,status,ipv4,type,location,created
+  echo
+  echo "Type $TYPE is billed hourly; 'destroy' stops the meter."
+  local ip; ip=$(server_ip 2>/dev/null) || return 0
+  ssh -o ConnectTimeout=5 "root@$ip" \
+    'systemctl is-active usajobs-backfill 2>/dev/null || true' 2>/dev/null \
+    | sed 's/^/backfill service: /'
+}
+
+cmd_logs() { ssh "root@$(server_ip)" 'journalctl -u usajobs-backfill -f -n 60'; }
+cmd_ssh()  { ssh "root@$(server_ip)"; }
+
+cmd_destroy() {
+  local ip; ip=$(server_ip) || { echo "$NAME does not exist"; return 0; }
+  read -r -p "Destroy $NAME ($ip)? Everything on it is lost. [y/N] " ok
+  [ "$ok" = "y" ] || { echo "cancelled"; return 0; }
+  hc server delete "$NAME"
+}
+
+case "${1:-}" in
+  create)    cmd_create ;;
+  provision) cmd_provision ;;
+  status)    cmd_status ;;
+  logs)      cmd_logs ;;
+  ssh)       cmd_ssh ;;
+  destroy)   cmd_destroy ;;
+  *) sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' ; exit 1 ;;
+esac


### PR DESCRIPTION
GitHub's free runners queue. The 2017 backfill spent **4h33m waiting and 5h working** — just over half the wall clock was queue — and 2018–2025 is 96 more jobs competing with the daily pipeline for the same starved pool.

The daily run is small and belongs in Actions. Bulk backfills don't.

## The console is needed exactly once

`deploy/server.sh` drives the whole server lifecycle through the Hetzner API, so the only GUI step is making a project and an API token.

```bash
./deploy/server.sh create     # create + bootstrap
./deploy/server.sh status     # what exists
./deploy/server.sh logs       # follow the job
./deploy/server.sh destroy    # stop paying
```

The token lives in `deploy/.hcloud.env`, gitignored (verified).

## Split generic from repo-specific

More repos are moving onto this box, so the setup is two halves:

`hetzner-bootstrap.sh` is generic and knows nothing about USAJOBS — worker user, `/srv/repos`, firewall, unattended security updates, a venv per checkout.

`install-backfill.sh` is the per-repo half and is meant to be copied. Only `REPO_URL`, the pip line, and the unit body change.

## Deliberately slower

6 concurrent fetches rather than 8 — about 8–9 pages/sec, so 2018–2025 (~2.9M pages) takes roughly **four days instead of three**. usajobs.gov has served 300k+ pages at this rate with zero failures and zero 404s, and there's no reason to lean harder on them to save a day.

`cx32` (8 GB) rather than the 4 GB size because `compact()` concatenates a month's shards in pandas and peaks near 1.6 GB.

## Nothing needs babysitting

`--known-from-hf` asks the dataset what's already published, so a restart continues rather than redoing work, and within a month pages land in shards that fold in at the end. A crash or reboot costs at most one month's partial fetch, and the unit restarts on failure.

Billing is hourly with a monthly cap, so running the backlog and destroying the box costs a euro or two rather than a month's price.

## Not touched

The Actions backfill workflow stays. It's the right tool for a single month later, and it's proven — 2017 published 12/12 through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV