### PR TITLE
Fix three things the first real server build found

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -42,7 +42,7 @@ ssh root@$IP 'bash -s' < deploy/install-backfill.sh
 
 ## Cost
 
-`cx32` (4 vCPU, 8 GB) is around €7–8/month, **billed hourly**. The backlog is
+`cx33` (4 vCPU, 8 GB) is €9.99/month or €0.016/hour, **billed hourly**. The backlog is
 about four days of work, so running it and destroying the box costs roughly a
 euro or two. The monthly figure is a cap, not a commitment — check the exact
 price in the create form, and destroy the server when the work is done.

--- a/deploy/server.sh
+++ b/deploy/server.sh
@@ -18,13 +18,25 @@
 set -euo pipefail
 
 NAME="${WORKER_NAME:-usajobs-worker}"
-TYPE="${WORKER_TYPE:-cx32}"          # 4 vCPU / 8 GB — the compact step peaks ~1.6 GB
+# cx33: 4 vCPU / 8 GB / 80 GB, EUR 9.99/mo or 0.016/hr as of 2026-09.
+# 8 GB rather than 4 because compact() concatenates a month's shards in pandas
+# and peaks near 1.6 GB. It is the cheapest 8 GB type; cax21 is ARM and dearer,
+# cpx32 is four times the price. Check `hcloud server-type list` if it 404s --
+# the line is versioned and cx32 was retired.
+TYPE="${WORKER_TYPE:-cx33}"
 IMAGE="${WORKER_IMAGE:-ubuntu-24.04}"
-LOCATION="${WORKER_LOCATION:-nbg1}"  # override if a location is out of stock
+# nbg1 was out of stock on 2026-09-05 ("error during placement,
+# resource_unavailable"), which is a normal thing for Hetzner to be. Try the
+# others if this one refuses: fsn1 hel1 (EU), ash hil (US), sin.
+LOCATION="${WORKER_LOCATION:-fsn1}"
 SSH_KEY_NAME="${WORKER_SSH_KEY:-}"   # name of the key as hcloud knows it
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-[ -f "$HERE/.hcloud.env" ] && . "$HERE/.hcloud.env"
+# set -a so the token is exported, not just set: hcloud is a child process and
+# a plain shell variable never reaches it.
+if [ -f "$HERE/.hcloud.env" ]; then
+  set -a; . "$HERE/.hcloud.env"; set +a
+fi
 
 need() { command -v "$1" >/dev/null || { echo "missing: $1"; exit 1; }; }
 


### PR DESCRIPTION
All three only surface when you actually build the box — none is reachable from `bash -n`.

**Exporting the token.** `server.sh` sourced `deploy/.hcloud.env` but never exported `HCLOUD_TOKEN`, so it was set in the shell and invisible to `hcloud`, which is a child process. Every command failed with `no active context or token`. Sourcing under `set -a` fixes it.

**Server type.** `cx32` doesn't exist — the line is versioned and that size was retired. `cx33` is the same shape (4 vCPU, 8 GB, 80 GB) and, checked against the API, the cheapest 8 GB type:

| type | spec | price |
|---|---|---|
| **cx33** | 4 core / 8 GB / 80 GB x86 | **€9.99/mo, €0.016/hr** |
| cax21 | 4 core / 8 GB / 80 GB arm | €12.49/mo |
| cpx32 | 4 core / 8 GB / 160 GB x86 | €41.99/mo |

So the backlog costs about **€1.50** to run, not the €7–8/mo the README guessed.

**Default location.** `nbg1` refused with `error during placement, resource_unavailable` — Hetzner's own console was flagging limited instance availability at the time. `fsn1` had stock. The comment now lists the alternatives.

The box is up and working: 2018 started at 12:07 UTC, twelve months planned, 329,356 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV