### PR TITLE
Resolve the mirror's list columns per file instead of hardcoding one shape

### DIFF
--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -48,7 +48,72 @@ BUILD_DIR = Path(__file__).resolve().parent.parent / "build" / "hf"
 # HiringPaths / JobCategories / PositionLocations, which are empty integer
 # columns superseded by the *_1 varchars; inserted_at / last_seen, which are
 # bookkeeping for this pipeline's own collection runs.
-METADATA_FIELDS = """
+# Structured fields, from the historical parquet.
+#
+# The mirror's schema is not stable across years, so the list-valued columns
+# are resolved per file rather than hardcoded:
+#
+#   hiringpaths_1 / jobcategories_1 / positionlocations_1
+#       VARCHAR in 2017, 2018, 2020, 2024, 2025, 2026 -- absent in 2019,
+#       2021, 2022, 2023
+#   HiringPaths / JobCategories / PositionLocations
+#       VARCHAR in every year except 2026, where they are empty integers
+#
+# Hardcoding the 2026 shape crashed on 2019 with 'Table "h" does not have a
+# column named "hiringpaths_1"'. Preferring the *_1 varchar and falling back to
+# the capitalised one covers every year.
+#
+# whoMayApply is cast because it is VARCHAR through 2024 and an empty INTEGER
+# from 2025 -- without the cast, month files disagree on its type and reading
+# the dataset as a whole breaks.
+#
+# Against the field list this replaces, positionTitle and hiringSubelementName
+# are new -- the published dataset had no job title in it at all.
+#
+# Not selected: usajobs_control_number (duplicates usajobsControlNumber);
+# inserted_at / last_seen, bookkeeping for this pipeline's own collection runs;
+# backfilled, which only exists in 2024 and 2025.
+# Three spellings have been observed for each of these, and which one holds
+# the data changes both across years and over time as the mirror is rewritten:
+#   hiringpaths_1   2017, 2018, 2020, 2024, 2025 and 2026 until 2026-09-05
+#   HiringPaths     every year, but empty or null-typed in the recent ones
+#   hiringpaths     the current 2026 mirror
+# Order is most- to least-specific; whichever is a string type and present wins.
+_LIST_COLUMNS = {
+    "hiringPaths": ("hiringpaths_1", "hiringpaths", "HiringPaths"),
+    "jobCategories": ("jobcategories_1", "jobcategories", "JobCategories"),
+    "positionLocations": ("positionlocations_1", "positionlocations",
+                          "PositionLocations"),
+}
+
+
+def resolve_list_columns(hist_path):
+    """Pick the column that actually holds each list field in this file.
+
+    Prefers the *_1 varchar, falls back to the capitalised one, and skips any
+    candidate that is not VARCHAR -- in 2026 the capitalised columns exist but
+    are empty integers.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    schema = pq.read_schema(hist_path)
+    # large_string as well as string: pyarrow distinguishes them and the
+    # mirror uses both. A column typed `null` is present but entirely empty,
+    # which is exactly what the capitalised ones are in recent years, so it
+    # must not win.
+    varchar = {f.name for f in schema
+               if pa.types.is_string(f.type) or pa.types.is_large_string(f.type)}
+    out = {}
+    for alias, candidates in _LIST_COLUMNS.items():
+        pick = next((c for c in candidates if c in varchar), None)
+        out[alias] = f"h.{pick}" if pick else "CAST(NULL AS VARCHAR)"
+    return out
+
+
+def metadata_fields(hist_path):
+    cols = resolve_list_columns(hist_path)
+    return f"""
     h.usajobsControlNumber::varchar AS usajobsControlNumber,
     h.positionTitle,
     h.announcementNumber,
@@ -56,7 +121,8 @@ METADATA_FIELDS = """
     h.hiringDepartmentCode, h.hiringDepartmentName,
     h.hiringSubelementName,
     h.agencyLevel, h.agencyLevelSort,
-    h.appointmentType, h.workSchedule, h.serviceType, h.whoMayApply,
+    h.appointmentType, h.workSchedule, h.serviceType,
+    CAST(h.whoMayApply AS VARCHAR) AS whoMayApply,
     h.payScale, h.salaryType, h.minimumSalary, h.maximumSalary,
     h.minimumGrade, h.maximumGrade, h.promotionPotential, h.supervisoryStatus,
     h.totalOpenings, h.positionOpeningStatus,
@@ -67,12 +133,13 @@ METADATA_FIELDS = """
     h.travelRequirement, h.teleworkEligible, h.relocationExpensesReimbursed,
     h.securityClearanceRequired, h.securityClearance, h.drugTestRequired,
     h.disableApplyOnline, h.vendor,
-    h.hiringpaths_1        AS hiringPaths,
-    h.jobcategories_1      AS jobCategories,
-    h.positionlocations_1  AS positionLocations,
+    {cols['hiringPaths']}        AS hiringPaths,
+    {cols['jobCategories']}      AS jobCategories,
+    {cols['positionLocations']}  AS positionLocations,
     array_to_string(
         regexp_extract_all(
-            coalesce(CAST(h.jobcategories_1 AS VARCHAR), ''), '[0-9]{4}'), ' | ')
+            coalesce(CAST({cols['jobCategories']} AS VARCHAR), ''),
+            '[0-9]{{4}}'), ' | ')
         AS occupationalSeries
 """
 
@@ -224,7 +291,7 @@ def select_sql(hist_path: str, scraped_path: str, month: str,
     text_cols = ",\n    ".join(f"t.{c}" for c in TEXT_FIELDS)
     return f"""
         WITH {", ".join(parts)}, txt AS ({union})
-        SELECT {METADATA_FIELDS},
+        SELECT {metadata_fields(hist_path)},
     {text_cols}
         FROM read_parquet('{hist_path}') h
         JOIN txt t ON h.usajobsControlNumber::varchar = t.cn

--- a/scripts/tests/test_publish_hf.py
+++ b/scripts/tests/test_publish_hf.py
@@ -12,9 +12,9 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-from publish_to_huggingface import (METADATA_FIELDS, TEXT_FIELDS,
+from publish_to_huggingface import (TEXT_FIELDS, metadata_fields,
                                     partition_safe_months,
-                                    prune_published_text)
+                                    prune_published_text, resolve_list_columns)
 
 
 class TestPartitionSafeMonths:
@@ -131,22 +131,87 @@ class TestGuardUsesTheExistingFile:
         assert safe == ["2026-09"]
 
 
+class TestResolveListColumns:
+    """Regression for the 2019 crash.
+
+    Each list-valued field has been spelled three ways in the mirror, and
+    which one holds the data varies by year and over time. Hardcoding the
+    2026 shape crashed on 2019 with 'does not have a column named
+    hiringpaths_1'.
+    """
+
+    def _schema(self, tmp_path, columns):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+        path = tmp_path / "mirror.parquet"
+        pq.write_table(pa.table({n: pa.array([None], type=t)
+                                 for n, t in columns.items()}), path)
+        return str(path)
+
+    def test_the_suffixed_varchar_wins_when_present(self, tmp_path):
+        import pyarrow as pa
+        path = self._schema(tmp_path, {"hiringpaths_1": pa.string(),
+                                       "hiringpaths": pa.string(),
+                                       "HiringPaths": pa.string()})
+        assert resolve_list_columns(path)["hiringPaths"] == "h.hiringpaths_1"
+
+    def test_falls_back_when_the_suffixed_one_is_absent(self, tmp_path):
+        # 2019, 2021, 2022, 2023 have only the capitalised column.
+        import pyarrow as pa
+        path = self._schema(tmp_path, {"HiringPaths": pa.string()})
+        assert resolve_list_columns(path)["hiringPaths"] == "h.HiringPaths"
+
+    def test_the_current_lowercase_spelling(self, tmp_path):
+        import pyarrow as pa
+        path = self._schema(tmp_path, {"hiringpaths": pa.string()})
+        assert resolve_list_columns(path)["hiringPaths"] == "h.hiringpaths"
+
+    def test_a_null_typed_column_does_not_win(self, tmp_path):
+        # Present but entirely empty, which is what the capitalised ones are
+        # in the recent mirrors. It must lose to a real string column.
+        import pyarrow as pa
+        path = self._schema(tmp_path, {"HiringPaths": pa.null(),
+                                       "hiringpaths": pa.string()})
+        assert resolve_list_columns(path)["hiringPaths"] == "h.hiringpaths"
+
+    def test_large_string_counts(self, tmp_path):
+        # pyarrow distinguishes string from large_string; the mirror uses both.
+        import pyarrow as pa
+        path = self._schema(tmp_path, {"hiringpaths": pa.large_string()})
+        assert resolve_list_columns(path)["hiringPaths"] == "h.hiringpaths"
+
+    def test_no_candidate_at_all_yields_null_not_a_crash(self, tmp_path):
+        import pyarrow as pa
+        path = self._schema(tmp_path, {"positionTitle": pa.string()})
+        assert resolve_list_columns(path)["hiringPaths"] == "CAST(NULL AS VARCHAR)"
+
+
 class TestPublishedSchema:
-    def test_the_job_title_is_selected(self):
+    def _fields(self, tmp_path):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+        path = tmp_path / "m.parquet"
+        pq.write_table(pa.table({"hiringpaths_1": pa.array([None], pa.string())}),
+                       path)
+        return metadata_fields(str(path))
+
+    def test_the_job_title_is_selected(self, tmp_path):
         # The field list this replaced omitted positionTitle, so the published
         # dataset had no job title in it at all.
-        assert "h.positionTitle," in METADATA_FIELDS
-        assert "h.hiringSubelementName," in METADATA_FIELDS
+        fields = self._fields(tmp_path)
+        assert "h.positionTitle," in fields
+        assert "h.hiringSubelementName," in fields
 
-    def test_bookkeeping_columns_are_not_published(self):
-        for column in ("inserted_at", "last_seen", "usajobs_control_number"):
-            assert f"h.{column}" not in METADATA_FIELDS
+    def test_bookkeeping_columns_are_not_published(self, tmp_path):
+        fields = self._fields(tmp_path)
+        for column in ("inserted_at", "last_seen", "usajobs_control_number",
+                       "backfilled"):
+            assert f"h.{column}" not in fields
 
-    def test_the_empty_integer_columns_are_not_published(self):
-        # HiringPaths / JobCategories / PositionLocations are empty integer
-        # columns in the mirror, superseded by the *_1 varchars.
-        assert "h.HiringPaths" not in METADATA_FIELDS
-        assert "h.hiringpaths_1" in METADATA_FIELDS
+    def test_who_may_apply_is_cast_for_a_stable_column_type(self, tmp_path):
+        # VARCHAR through 2024, empty INTEGER from 2025. Without the cast the
+        # month files disagree and the dataset cannot be read as a whole.
+        assert "CAST(h.whoMayApply AS VARCHAR)" in self._fields(tmp_path)
 
     def test_every_announcement_section_is_published(self):
         for section in ("jobSummary", "majorDuties", "qualificationSummary",


### PR DESCRIPTION
The box crashed on 2019:

```
BinderException: Table "h" does not have a column named "hiringpaths_1"
Candidate bindings: "HiringPaths"
```

I wrote the field list against the 2026 schema and assumed it held for every year. It doesn't. 2018 published fine, then every 2019 month fetched successfully and failed to publish.

## Three spellings, and they move

Surveying 2017–2026, each list-valued field has been spelled three different ways, and which one carries the data varies both across years *and over time* as the mirror gets rewritten:

| spelling | where |
|---|---|
| `hiringpaths_1` | 2017, 2018, 2020, 2024, 2025 — and 2026 until 2026-09-05 |
| `HiringPaths` | present every year, but null-typed or empty in recent ones |
| `hiringpaths` | the current 2026 mirror |

That last row is the striking one: the 2026 mirror changed shape *today*, between the morning daily run and this afternoon.

So columns are now resolved per file — first candidate that's present and is a string type. A `null`-typed column is present but entirely empty, which is exactly what the capitalised ones are now, so it must not win. `large_string` counts as well as `string`; pyarrow distinguishes them and the mirror uses both.

## A second, latent problem

`whoMayApply` is VARCHAR through 2024 and an empty INTEGER from 2025. 2017 and 2026 were already published with the two different types, so reading the dataset as a whole would break. It's now cast to VARCHAR.

## Separately — worth investigating, not caused by this

The **2026 mirror on R2 currently has all three list columns empty** — 0 of 175,926 rows under every spelling. Today's published `2026_09` has them populated (3,836/3,836), so the data existed when CI published and the file was rewritten without it afterwards. That affects `prep_web_data.py` too, which reads the same columns. Flagging rather than fixing, since it's in the main collection path.

## Tests

136 passing, 6 new on the resolution itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV