### PR TITLE
Resolve list columns through duckdb's schema, not the parquet's

### DIFF
--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -79,6 +79,9 @@ BUILD_DIR = Path(__file__).resolve().parent.parent / "build" / "hf"
 #   HiringPaths     every year, but empty or null-typed in the recent ones
 #   hiringpaths     the current 2026 mirror
 # Order is most- to least-specific; whichever is a string type and present wins.
+# Candidate names as DUCKDB reports them, most- to least-specific. The `_1`
+# forms are duckdb's own de-collision of a case-insensitive clash in the file;
+# they are not column names in the parquet.
 _LIST_COLUMNS = {
     "hiringPaths": ("hiringpaths_1", "hiringpaths", "HiringPaths"),
     "jobCategories": ("jobcategories_1", "jobcategories", "JobCategories"),
@@ -87,32 +90,35 @@ _LIST_COLUMNS = {
 }
 
 
-def resolve_list_columns(hist_path):
+def resolve_list_columns(con, hist_path):
     """Pick the column that actually holds each list field in this file.
 
-    Prefers the *_1 varchar, falls back to the capitalised one, and skips any
-    candidate that is not VARCHAR -- in 2026 the capitalised columns exist but
-    are empty integers.
-    """
-    import pyarrow as pa
-    import pyarrow.parquet as pq
+    Resolved through duckdb's view of the schema, not pyarrow's, because the
+    two disagree in a way that matters. The mirror carries both `HiringPaths`
+    (a vestigial, entirely null column) and `hiringpaths` (the real data). SQL
+    identifiers are case-insensitive, so duckdb sees a collision and exposes
+    the second as `hiringpaths_1` -- and a query saying `h.hiringpaths` binds
+    to the FIRST match, which is the empty one.
 
-    schema = pq.read_schema(hist_path)
-    # large_string as well as string: pyarrow distinguishes them and the
-    # mirror uses both. A column typed `null` is present but entirely empty,
-    # which is exactly what the capitalised ones are in recent years, so it
-    # must not win.
-    varchar = {f.name for f in schema
-               if pa.types.is_string(f.type) or pa.types.is_large_string(f.type)}
+    Reading the parquet schema and emitting `h.hiringpaths` therefore produced
+    175,926 rows of NULL hiring paths while looking entirely correct. The name
+    to emit is the one duckdb reports.
+
+    Years differ in which columns exist at all: 2019, 2021, 2022 and 2023 have
+    a single spelling and so no collision and no `_1`, which is what crashed
+    the publisher on 2019.
+    """
+    types = {n: t for n, t, *_ in
+             con.execute(f"DESCRIBE SELECT * FROM read_parquet('{hist_path}')").fetchall()}
     out = {}
     for alias, candidates in _LIST_COLUMNS.items():
-        pick = next((c for c in candidates if c in varchar), None)
+        pick = next((c for c in candidates if types.get(c) == "VARCHAR"), None)
         out[alias] = f"h.{pick}" if pick else "CAST(NULL AS VARCHAR)"
     return out
 
 
-def metadata_fields(hist_path):
-    cols = resolve_list_columns(hist_path)
+def metadata_fields(con, hist_path):
+    cols = resolve_list_columns(con, hist_path)
     return f"""
     h.usajobsControlNumber::varchar AS usajobsControlNumber,
     h.positionTitle,
@@ -249,7 +255,7 @@ def parquet_columns(path):
     return set(pq.read_schema(path).names)
 
 
-def select_sql(hist_path: str, scraped_path: str, month: str,
+def select_sql(con, hist_path: str, scraped_path: str, month: str,
                prior_path: str = None) -> str:
     """Fresh metadata joined to announcement text from wherever it still lives.
 
@@ -291,7 +297,7 @@ def select_sql(hist_path: str, scraped_path: str, month: str,
     text_cols = ",\n    ".join(f"t.{c}" for c in TEXT_FIELDS)
     return f"""
         WITH {", ".join(parts)}, txt AS ({union})
-        SELECT {metadata_fields(hist_path)},
+        SELECT {metadata_fields(con, hist_path)},
     {text_cols}
         FROM read_parquet('{hist_path}') h
         JOIN txt t ON h.usajobsControlNumber::varchar = t.cn
@@ -479,7 +485,7 @@ def main() -> int:
         # COPY streams straight to disk. Materializing a month in Python would
         # be ~800 MB of announcement text.
         con.execute(f"""
-            COPY ({select_sql(str(hist), str(scraped), month, priors.get(month))}
+            COPY ({select_sql(con, str(hist), str(scraped), month, priors.get(month))}
                   ORDER BY usajobsControlNumber)
             TO '{dest}' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 19);
         """)

--- a/scripts/tests/test_publish_hf.py
+++ b/scripts/tests/test_publish_hf.py
@@ -132,68 +132,74 @@ class TestGuardUsesTheExistingFile:
 
 
 class TestResolveListColumns:
-    """Regression for the 2019 crash.
+    """Regression for two bugs, one of which hid inside the fix for the other.
 
-    Each list-valued field has been spelled three ways in the mirror, and
-    which one holds the data varies by year and over time. Hardcoding the
-    2026 shape crashed on 2019 with 'does not have a column named
-    hiringpaths_1'.
+    First: hardcoding the 2026 column name crashed on 2019 with 'does not have
+    a column named hiringpaths_1'.
+
+    Then: resolving against the *parquet* schema and emitting `h.hiringpaths`
+    silently produced 175,926 rows of NULL, because the file carries both
+    `HiringPaths` (vestigial, all null) and `hiringpaths` (the real data), SQL
+    identifiers are case-insensitive, and the query bound to the first match.
+    duckdb exposes the second as `hiringpaths_1`, and that is the name to emit.
     """
 
-    def _schema(self, tmp_path, columns):
+    def _mirror(self, tmp_path, columns):
         import pyarrow as pa
         import pyarrow.parquet as pq
         path = tmp_path / "mirror.parquet"
-        pq.write_table(pa.table({n: pa.array([None], type=t)
-                                 for n, t in columns.items()}), path)
+        pq.write_table(pa.table({n: pa.array([v], type=t)
+                                 for n, (t, v) in columns.items()}), path)
         return str(path)
 
-    def test_the_suffixed_varchar_wins_when_present(self, tmp_path):
-        import pyarrow as pa
-        path = self._schema(tmp_path, {"hiringpaths_1": pa.string(),
-                                       "hiringpaths": pa.string(),
-                                       "HiringPaths": pa.string()})
-        assert resolve_list_columns(path)["hiringPaths"] == "h.hiringpaths_1"
+    def test_the_2026_shape_picks_the_populated_column(self, tmp_path):
+        # Both spellings present; the capitalised one is an empty null column.
+        # duckdb de-collides them and only the _1 form holds data.
+        import duckdb, pyarrow as pa
+        path = self._mirror(tmp_path, {
+            "HiringPaths": (pa.null(), None),
+            "hiringpaths": (pa.string(), '[{"hiringPath": "The public"}]')})
+        con = duckdb.connect()
+        picked = resolve_list_columns(con, path)["hiringPaths"]
+        assert picked == "h.hiringpaths_1"
+        # and it must actually select the data, not the empty column
+        got = con.execute(
+            f"SELECT {picked} FROM read_parquet('{path}') h").fetchone()[0]
+        assert got == '[{"hiringPath": "The public"}]'
 
-    def test_falls_back_when_the_suffixed_one_is_absent(self, tmp_path):
-        # 2019, 2021, 2022, 2023 have only the capitalised column.
-        import pyarrow as pa
-        path = self._schema(tmp_path, {"HiringPaths": pa.string()})
-        assert resolve_list_columns(path)["hiringPaths"] == "h.HiringPaths"
+    def test_the_2019_shape_has_no_collision(self, tmp_path):
+        # A single spelling, so duckdb adds no suffix and the _1 form is absent.
+        import duckdb, pyarrow as pa
+        path = self._mirror(tmp_path, {
+            "HiringPaths": (pa.string(), '[{"hiringPath": "The public"}]')})
+        con = duckdb.connect()
+        picked = resolve_list_columns(con, path)["hiringPaths"]
+        assert picked == "h.HiringPaths"
+        got = con.execute(
+            f"SELECT {picked} FROM read_parquet('{path}') h").fetchone()[0]
+        assert got == '[{"hiringPath": "The public"}]'
 
-    def test_the_current_lowercase_spelling(self, tmp_path):
-        import pyarrow as pa
-        path = self._schema(tmp_path, {"hiringpaths": pa.string()})
-        assert resolve_list_columns(path)["hiringPaths"] == "h.hiringpaths"
-
-    def test_a_null_typed_column_does_not_win(self, tmp_path):
-        # Present but entirely empty, which is what the capitalised ones are
-        # in the recent mirrors. It must lose to a real string column.
-        import pyarrow as pa
-        path = self._schema(tmp_path, {"HiringPaths": pa.null(),
-                                       "hiringpaths": pa.string()})
-        assert resolve_list_columns(path)["hiringPaths"] == "h.hiringpaths"
-
-    def test_large_string_counts(self, tmp_path):
-        # pyarrow distinguishes string from large_string; the mirror uses both.
-        import pyarrow as pa
-        path = self._schema(tmp_path, {"hiringpaths": pa.large_string()})
-        assert resolve_list_columns(path)["hiringPaths"] == "h.hiringpaths"
+    def test_a_null_typed_column_never_wins(self, tmp_path):
+        import duckdb, pyarrow as pa
+        path = self._mirror(tmp_path, {"HiringPaths": (pa.null(), None)})
+        assert resolve_list_columns(duckdb.connect(), path)["hiringPaths"] \
+            == "CAST(NULL AS VARCHAR)"
 
     def test_no_candidate_at_all_yields_null_not_a_crash(self, tmp_path):
-        import pyarrow as pa
-        path = self._schema(tmp_path, {"positionTitle": pa.string()})
-        assert resolve_list_columns(path)["hiringPaths"] == "CAST(NULL AS VARCHAR)"
+        import duckdb, pyarrow as pa
+        path = self._mirror(tmp_path, {"positionTitle": (pa.string(), "x")})
+        cols = resolve_list_columns(duckdb.connect(), path)
+        assert all(v == "CAST(NULL AS VARCHAR)" for v in cols.values())
 
 
 class TestPublishedSchema:
     def _fields(self, tmp_path):
-        import pyarrow as pa
+        import duckdb, pyarrow as pa
         import pyarrow.parquet as pq
         path = tmp_path / "m.parquet"
-        pq.write_table(pa.table({"hiringpaths_1": pa.array([None], pa.string())}),
+        pq.write_table(pa.table({"hiringpaths": pa.array([None], pa.string())}),
                        path)
-        return metadata_fields(str(path))
+        return metadata_fields(duckdb.connect(), str(path))
 
     def test_the_job_title_is_selected(self, tmp_path):
         # The field list this replaced omitted positionTitle, so the published


### PR DESCRIPTION
The previous fix was silently wrong, and finding out why explains every confusing thing about these columns.

## What was happening

It read the **parquet** schema and emitted `h.hiringpaths`. That produced **175,926 rows of NULL** hiring paths for 2026 while looking entirely correct.

The mirror carries two columns: `HiringPaths` (vestigial, entirely null) and `hiringpaths` (the real data). SQL identifiers are case-insensitive, so `h.hiringpaths` binds to the *first* match — the empty one.

duckdb sees the collision and exposes the real column as **`hiringpaths_1`**. So:

- `_1` was never a column name in any file — it's duckdb's de-collision
- which is why the original hardcoded `hiringpaths_1` worked for 2026
- and why no such name exists for 2019: that file has a single spelling, no collision, no suffix
- and why resolving in pyarrow's namespace and emitting into duckdb's produced nulls

Resolution now happens in duckdb's namespace, so the emitted name binds to the intended column.

| year | hiringPaths populated |
|---|---:|
| 2019 | 349,256 / 349,256 |
| 2026 | 175,920 / 175,926 |

The broken version gave 0 for 2026.

## Nothing shipped

Only `2018_01` is published, under the original hardcoded name, which was correct for that file. Caught before 2018-02 finished.

## Retraction

This also withdraws the "2026 mirror has lost its list columns" finding from the previous PR. **The mirror is intact** — 175,920 of 175,926 populated. The count that suggested otherwise was itself resolving to the empty column, the same bug one level up.

## Tests

134 passing. The resolution tests now build the two real shapes — 2026's collision and 2019's single spelling — and assert the picked name actually selects the data, not just that it has the right string value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV