### PR TITLE
Make the section tripwire carry its own diagnosis

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -435,7 +435,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: scrape-vs-api-report
-        path: logs/scrape_vs_api_*.md
+        path: |
+          logs/scrape_vs_api_*.md
+          logs/scrape_field_health.json
+          logs/scrape_samples/*.html
         if-no-files-found: ignore
         retention-days: 90
 

--- a/scripts/collect_scraped_data.py
+++ b/scripts/collect_scraped_data.py
@@ -47,9 +47,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cap_alert import check_cap
 from collect_current_data import (get_year_from_date, group_jobs_by_year,
                                   load_existing_jobs, save_jobs_to_parquet)
-from usajobs_scrape import (MAX_RESULTS, SECTION_FIELDS, fetch_job_page,
-                            new_session, normalize_search_job, open_inventory,
-                            parse_job_page, search_slice)
+from usajobs_scrape import (MAX_RESULTS, SECTION_FIELDS, diagnose_structure,
+                            fetch_job_page, new_session, normalize_search_job,
+                            open_inventory, parse_job_page, search_slice)
 
 # Under this fraction of the inventory the facets promised, something in
 # discovery is silently dropping postings and the run should be looked at.
@@ -66,6 +66,18 @@ WARNING_FILE = os.path.join(os.path.dirname(__file__), "..", "logs",
 # pages were parsing at 12/12.
 HEALTH_FILE = os.path.join(os.path.dirname(__file__), "..", "logs",
                            "scrape_field_health.json")
+
+# When a section stops parsing, the fill rate alone only says which field
+# broke. These keep a page it broke on, so the alarm carries its own evidence
+# and diagnosing it does not mean opening a browser.
+SAMPLE_DIR = os.path.join(os.path.dirname(__file__), "..", "logs",
+                          "scrape_samples")
+MAX_SAMPLES = 2
+
+# education and benefits are legitimately absent on plenty of announcements,
+# so a page missing only those is not evidence of anything.
+_ALWAYS_EXPECTED = [f for f in SECTION_FIELDS
+                    if f not in ("education", "benefits")]
 
 # 'education' is genuinely absent from about one announcement in six.
 MIN_FILL = {"education": 0.50}
@@ -191,6 +203,7 @@ def add_details(rows: List[Dict], known: set, workers: int,
     fetched = 0
     failures = set()
     gone = set()
+    samples = []
     lock = threading.Lock()
     started = time.time()
 
@@ -222,6 +235,9 @@ def add_details(rows: List[Dict], known: set, workers: int,
                 row[key] = value
         with lock:
             fetched += 1
+            if (len(samples) < MAX_SAMPLES
+                    and any(not detail.get(f) for f in _ALWAYS_EXPECTED)):
+                samples.append((cn, html))
 
     with ThreadPoolExecutor(max_workers=workers) as pool:
         list(tqdm(pool.map(work, todo), total=len(todo),
@@ -235,11 +251,11 @@ def add_details(rows: List[Dict], known: set, workers: int,
 
     parsed = [r for r in todo
               if r["usajobs_control_number"] not in failures | gone]
-    record_field_health(parsed)
+    record_field_health(parsed, samples)
     return skipped | failures
 
 
-def record_field_health(parsed: List[Dict]) -> None:
+def record_field_health(parsed: List[Dict], samples=None) -> None:
     """Fill rates for the announcement sections on the pages parsed this run.
 
     This is the only check on whether the HTML parse still works — the API has
@@ -260,6 +276,7 @@ def record_field_health(parsed: List[Dict]) -> None:
         json.dump({"measured_at": datetime.now().isoformat(),
                    "pages_parsed": len(parsed), "fields": stats}, f, indent=2)
 
+    below = []
     print(f"Announcement section fill over {len(parsed):,} pages parsed:")
     for field, st in stats.items():
         floor = MIN_FILL.get(field, MIN_FILL_DEFAULT)
@@ -267,9 +284,47 @@ def record_field_health(parsed: List[Dict]) -> None:
         print(f"   {st['filled']:6,}/{st['parsed']:,}  {st['rate']:6.1%}  "
               f"{field}{flag}")
         if st["rate"] < floor:
+            below.append(field)
             warn(f"Announcement section '{field}' parsed out of only "
                  f"{st['rate']:.1%} of {len(parsed):,} pages fetched this run; "
                  f"floor is {floor:.0%}. The page markup has probably changed.")
+
+    if below:
+        report_structure(samples or [], below)
+
+
+def report_structure(samples, below) -> None:
+    """Say what the page looks like now, and keep a copy of one.
+
+    A fill rate says which field broke. This says why: which section ids the
+    page still has, which headings sit inside Requirements, and which of those
+    the parser cannot map -- that last list is the answer whenever a heading
+    gets renamed. Without it the alarm means opening a browser.
+    """
+    if not samples:
+        warn(f"{len(below)} section(s) below floor but no sample page was "
+             f"kept, because every page parsed cleanly. The shortfall is in "
+             f"which pages were fetched, not in the markup.")
+        return
+
+    os.makedirs(SAMPLE_DIR, exist_ok=True)
+    for cn, html in samples:
+        with open(os.path.join(SAMPLE_DIR, f"{cn}.html"), "w",
+                  encoding="utf-8") as f:
+            f.write(html)
+
+    cn, html = samples[0]
+    try:
+        structure = diagnose_structure(html)
+    except Exception as e:
+        warn(f"Could not diagnose the sample page {cn}: {e}")
+        return
+
+    warn(f"Structure of {cn}, a page where a section did not parse: "
+         + json.dumps(structure, separators=(",", ":")))
+    print(f"\nStructure of {cn} (full page saved under {SAMPLE_DIR}):")
+    for key, value in structure.items():
+        print(f"   {key}: {value}")
 
 
 def main() -> None:

--- a/scripts/tests/test_scrape_health.py
+++ b/scripts/tests/test_scrape_health.py
@@ -25,6 +25,7 @@ from usajobs_scrape import SECTION_FIELDS
 def isolate(tmp_path, monkeypatch):
     monkeypatch.setattr(csd, "HEALTH_FILE", str(tmp_path / "health.json"))
     monkeypatch.setattr(csd, "WARNING_FILE", str(tmp_path / "warning.txt"))
+    monkeypatch.setattr(csd, "SAMPLE_DIR", str(tmp_path / "samples"))
     return tmp_path
 
 
@@ -82,3 +83,56 @@ class TestRecordFieldHealth:
     def test_every_parser_section_is_measured(self, isolate):
         csd.record_field_health([row()])
         assert set(health(isolate)["fields"]) == set(SECTION_FIELDS)
+
+
+class TestStructureDiagnosis:
+    """A fill rate says which section broke. The alarm should also say why.
+
+    Without this, a markup change means reading a rate, opening a browser and
+    diffing the page by eye. With it, the warning names the headings the
+    parser can no longer map -- which is the whole answer when one is renamed.
+    """
+
+    def _page(self, requirements_headings):
+        h3 = "".join(f"<h3>{h}</h3><p>body</p>" for h in requirements_headings)
+        ids = "".join(f'<div id="{i}"><h2>x</h2><p>body</p></div>'
+                      for i in ("joa-summary", "joa-duties", "joa-evaluation",
+                                "joa-required-documents", "joa-how-to-apply"))
+        return (f"<html><body>{ids}"
+                f'<div id="joa-requirements"><h2>Requirements</h2>{h3}</div>'
+                f"</body></html>")
+
+    def test_a_renamed_heading_is_named_in_the_warning(self, isolate):
+        # The realistic break: "Qualifications" becomes something else.
+        page = self._page(["Conditions of employment", "Who may apply",
+                           "Additional information"])
+        csd.record_field_health(
+            [row(qualificationSummary=None) for _ in range(100)],
+            samples=[("999", page)])
+        text = warnings(isolate)
+        assert "qualificationSummary" in text
+        assert "Who may apply" in text          # the heading we cannot map
+        assert "headings_the_parser_cannot_map" in text
+
+    def test_the_sample_page_is_kept(self, isolate):
+        page = self._page(["Conditions of employment"])
+        csd.record_field_health([row(majorDuties=None) for _ in range(100)],
+                                samples=[("12345", page)])
+        saved = isolate / "samples" / "12345.html"
+        assert saved.exists() and saved.read_text() == page
+
+    def test_a_healthy_run_writes_no_sample(self, isolate):
+        csd.record_field_health([row() for _ in range(100)],
+                                samples=[("1", self._page(["Qualifications"]))])
+        assert not (isolate / "samples").exists()
+
+    def test_below_floor_with_no_sample_says_so_rather_than_crashing(self, isolate):
+        csd.record_field_health([row(majorDuties=None) for _ in range(100)],
+                                samples=[])
+        assert "no sample page was kept" in warnings(isolate)
+
+    def test_unparseable_sample_does_not_take_the_run_down(self, isolate):
+        csd.record_field_health([row(majorDuties=None) for _ in range(100)],
+                                samples=[("7", "<html>")])
+        # No requirements block at all: still reports, still names the field.
+        assert "majorDuties" in warnings(isolate)

--- a/scripts/usajobs_scrape.py
+++ b/scripts/usajobs_scrape.py
@@ -327,6 +327,38 @@ SECTION_FIELDS = [
 ]
 
 
+def diagnose_structure(html: str) -> Dict:
+    """What the page's structure looks like now, versus what the parser expects.
+
+    This is what turns a fill-rate alarm into a diagnosis. The tripwire can
+    only say "qualificationSummary stopped parsing"; this says which section
+    ids the page actually has, which <h3> headings are inside Requirements, and
+    which of those the parser has no mapping for -- which is the answer when a
+    heading gets renamed.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    present_ids = sorted({d.get("id") for d in soup.select("[id^=joa-]")})
+    expected_ids = sorted(set(_SECTIONS) | {"joa-requirements"})
+
+    requirements = soup.find(id="joa-requirements")
+    headings = ([_WS.sub(" ", h.get_text(" ")).strip()
+                 for h in requirements.find_all("h3")] if requirements else [])
+    unmapped = [h for h in headings if h.lower() not in _REQUIREMENT_PARTS]
+    missing_headings = [k for k in _REQUIREMENT_PARTS
+                        if k not in {h.lower() for h in headings}]
+
+    return {
+        "section_ids_present": present_ids,
+        "section_ids_expected_but_absent": [i for i in expected_ids
+                                            if i not in present_ids],
+        "requirements_headings": headings,
+        "headings_the_parser_cannot_map": unmapped,
+        "expected_headings_not_on_the_page": missing_headings,
+        "page_bytes": len(html),
+    }
+
+
 def parse_sections(soup: BeautifulSoup) -> Dict[str, str]:
     """The long-text fields, keyed by the name the row will carry."""
     out: Dict[str, str] = {}


### PR DESCRIPTION
The fill-rate alarm could only say *which* section stopped parsing. Acting on it meant opening a browser and diffing the page by eye.

That matters more than it sounds, because this is the **only** check on the eleven text fields — the API has no counterpart for them, so there's nothing to diff against.

## What it says now

`diagnose_structure` reports what the page looks like against what the parser expects:

```
section_ids_present: [joa-duties, joa-requirements, joa-summary, ...]
section_ids_expected_but_absent: []
requirements_headings: [Conditions of employment, Who may apply, Additional information]
headings_the_parser_cannot_map: [Who may apply]      <-- the answer
expected_headings_not_on_the_page: [qualifications]
```

A renamed heading is the realistic break, and that fourth line names it outright. The fix is then one line in `_REQUIREMENT_PARTS`.

`collect_scraped_data` keeps up to two pages a section failed to parse on, writes them under `logs/scrape_samples/`, and folds the summary into the warning. `education` and `benefits` are excluded from what counts as a failure — both are legitimately absent from plenty of announcements.

The daily workflow uploads the samples and the health JSON with the comparison report, so the evidence outlives the run.

## Why now

Today produced three alarms that were confidently wrong:

| alarm | what was actually true |
|---|---|
| "twelve fields at 47.2%, markup changed" | measuring rows whose text had been pruned after publishing |
| "would drop 4 announcements" | comparing against the manifest rather than the file that holds them |
| "2026 mirror lost its list columns" | the count itself resolved to an empty duplicate column |

None crashed. Each needed someone to go look. This is the cheapest version of going to look, applied to the one check with no independent verification behind it.

## Tests

139 passing, 5 new — including that a renamed heading is named in the warning, that a healthy run writes no sample, and that an unparseable sample doesn't take the run down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV