### PR TITLE
Pick the list column by which one holds data, not by its name

### DIFF
--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -79,9 +79,10 @@ BUILD_DIR = Path(__file__).resolve().parent.parent / "build" / "hf"
 #   HiringPaths     every year, but empty or null-typed in the recent ones
 #   hiringpaths     the current 2026 mirror
 # Order is most- to least-specific; whichever is a string type and present wins.
-# Candidate names as DUCKDB reports them, most- to least-specific. The `_1`
-# forms are duckdb's own de-collision of a case-insensitive clash in the file;
-# they are not column names in the parquet.
+# Candidate names as DUCKDB reports them. Order does not matter -- the
+# fullest column wins -- but both spellings have to be listed. The `_1` forms
+# are duckdb's own de-collision of a case-insensitive clash in the file; they
+# are not column names in any parquet.
 _LIST_COLUMNS = {
     "hiringPaths": ("hiringpaths_1", "hiringpaths", "HiringPaths"),
     "jobCategories": ("jobcategories_1", "jobcategories", "JobCategories"),
@@ -93,27 +94,36 @@ _LIST_COLUMNS = {
 def resolve_list_columns(con, hist_path):
     """Pick the column that actually holds each list field in this file.
 
-    Resolved through duckdb's view of the schema, not pyarrow's, because the
-    two disagree in a way that matters. The mirror carries both `HiringPaths`
-    (a vestigial, entirely null column) and `hiringpaths` (the real data). SQL
-    identifiers are case-insensitive, so duckdb sees a collision and exposes
-    the second as `hiringpaths_1` -- and a query saying `h.hiringpaths` binds
-    to the FIRST match, which is the empty one.
+    Chosen by which candidate has the most non-null values, because nothing
+    about the name is a reliable signal. Two earlier rules both failed:
 
-    Reading the parquet schema and emitting `h.hiringpaths` therefore produced
-    175,926 rows of NULL hiring paths while looking entirely correct. The name
-    to emit is the one duckdb reports.
+      hardcoding `hiringpaths_1`   crashed on 2019, which has no such column
+      preferring `hiringpaths_1`   published nulls for 2017 and 2018, where
+                                   HiringPaths holds 237,145 and 328,111 rows
+                                   and hiringpaths_1 holds 1 and 1,245
 
-    Years differ in which columns exist at all: 2019, 2021, 2022 and 2023 have
-    a single spelling and so no collision and no `_1`, which is what crashed
-    the publisher on 2019.
+    Measured across 2017-2026, HiringPaths is the populated column in every
+    year except 2026, where it is empty and hiringpaths_1 has all 175,920.
+    So the name tells you nothing and the data tells you everything.
+
+    Resolution happens in duckdb's namespace, not the parquet's: the file
+    carries two columns differing only in case, SQL identifiers are
+    case-insensitive, and duckdb exposes the second as `hiringpaths_1`. Reading
+    pyarrow's names and emitting them into SQL binds to the wrong one.
     """
     types = {n: t for n, t, *_ in
              con.execute(f"DESCRIBE SELECT * FROM read_parquet('{hist_path}')").fetchall()}
     out = {}
     for alias, candidates in _LIST_COLUMNS.items():
-        pick = next((c for c in candidates if types.get(c) == "VARCHAR"), None)
-        out[alias] = f"h.{pick}" if pick else "CAST(NULL AS VARCHAR)"
+        best, best_n = None, 0
+        for c in candidates:
+            if types.get(c) != "VARCHAR":
+                continue
+            n = con.execute(
+                f'SELECT count("{c}") FROM read_parquet(\'{hist_path}\')').fetchone()[0]
+            if n > best_n:
+                best, best_n = c, n
+        out[alias] = f"h.{best}" if best else "CAST(NULL AS VARCHAR)"
     return out
 
 

--- a/scripts/tests/test_publish_hf.py
+++ b/scripts/tests/test_publish_hf.py
@@ -148,46 +148,56 @@ class TestResolveListColumns:
         import pyarrow as pa
         import pyarrow.parquet as pq
         path = tmp_path / "mirror.parquet"
-        pq.write_table(pa.table({n: pa.array([v], type=t)
+        pq.write_table(pa.table({n: pa.array(v, type=t)
                                  for n, (t, v) in columns.items()}), path)
         return str(path)
 
-    def test_the_2026_shape_picks_the_populated_column(self, tmp_path):
-        # Both spellings present; the capitalised one is an empty null column.
-        # duckdb de-collides them and only the _1 form holds data.
+    def test_the_fullest_column_wins_not_the_suffixed_one(self, tmp_path):
+        # The 2017/2018 shape: both spellings are VARCHAR, and the one duckdb
+        # suffixes is the near-empty one. Preferring _1 by name published
+        # 237,145 rows of NULL for 2017.
         import duckdb, pyarrow as pa
         path = self._mirror(tmp_path, {
-            "HiringPaths": (pa.null(), None),
-            "hiringpaths": (pa.string(), '[{"hiringPath": "The public"}]')})
-        con = duckdb.connect()
-        picked = resolve_list_columns(con, path)["hiringPaths"]
-        assert picked == "h.hiringpaths_1"
-        # and it must actually select the data, not the empty column
-        got = con.execute(
-            f"SELECT {picked} FROM read_parquet('{path}') h").fetchone()[0]
-        assert got == '[{"hiringPath": "The public"}]'
-
-    def test_the_2019_shape_has_no_collision(self, tmp_path):
-        # A single spelling, so duckdb adds no suffix and the _1 form is absent.
-        import duckdb, pyarrow as pa
-        path = self._mirror(tmp_path, {
-            "HiringPaths": (pa.string(), '[{"hiringPath": "The public"}]')})
+            "HiringPaths": (pa.string(), ["a", "b", "c"]),
+            "hiringpaths": (pa.string(), [None, None, "x"])})
         con = duckdb.connect()
         picked = resolve_list_columns(con, path)["hiringPaths"]
         assert picked == "h.HiringPaths"
         got = con.execute(
-            f"SELECT {picked} FROM read_parquet('{path}') h").fetchone()[0]
-        assert got == '[{"hiringPath": "The public"}]'
+            f"SELECT {picked} FROM read_parquet('{path}') h").fetchall()
+        assert [r[0] for r in got] == ["a", "b", "c"]
 
-    def test_a_null_typed_column_never_wins(self, tmp_path):
+    def test_the_2026_shape_picks_the_suffixed_one(self, tmp_path):
+        # Here the capitalised column is the empty one, so the suffixed form
+        # wins on data even though it loses on name order.
         import duckdb, pyarrow as pa
-        path = self._mirror(tmp_path, {"HiringPaths": (pa.null(), None)})
+        path = self._mirror(tmp_path, {
+            "HiringPaths": (pa.null(), [None, None, None]),
+            "hiringpaths": (pa.string(), ["a", "b", "c"])})
+        con = duckdb.connect()
+        picked = resolve_list_columns(con, path)["hiringPaths"]
+        assert picked == "h.hiringpaths_1"
+        got = con.execute(
+            f"SELECT {picked} FROM read_parquet('{path}') h").fetchall()
+        assert [r[0] for r in got] == ["a", "b", "c"]
+
+    def test_the_2019_shape_has_no_collision(self, tmp_path):
+        import duckdb, pyarrow as pa
+        path = self._mirror(tmp_path, {
+            "HiringPaths": (pa.string(), ["a", "b", "c"])})
+        assert resolve_list_columns(duckdb.connect(), path)["hiringPaths"] \
+            == "h.HiringPaths"
+
+    def test_an_entirely_empty_candidate_never_wins(self, tmp_path):
+        import duckdb, pyarrow as pa
+        path = self._mirror(tmp_path, {
+            "HiringPaths": (pa.string(), [None, None, None])})
         assert resolve_list_columns(duckdb.connect(), path)["hiringPaths"] \
             == "CAST(NULL AS VARCHAR)"
 
     def test_no_candidate_at_all_yields_null_not_a_crash(self, tmp_path):
         import duckdb, pyarrow as pa
-        path = self._mirror(tmp_path, {"positionTitle": (pa.string(), "x")})
+        path = self._mirror(tmp_path, {"positionTitle": (pa.string(), ["x"] * 3)})
         cols = resolve_list_columns(duckdb.connect(), path)
         assert all(v == "CAST(NULL AS VARCHAR)" for v in cols.values())
 


### PR DESCRIPTION
2017 and 2018 published with **NULL** `hiringPaths`, `jobCategories` and `positionLocations` — 19 month files affected.

## Third rule, and this one is measured

| rule | outcome |
|---|---|
| hardcode `hiringpaths_1` | crashed on 2019, which has no such column |
| prefer `hiringpaths_1` by name | published nulls for 2017 and 2018 |
| **take the fullest column** | correct on all ten years |

The reason the second rule failed:

| year | `HiringPaths` | `hiringpaths_1` |
|---|---:|---:|
| 2017 | **237,145** | 1 |
| 2018 | **328,111** | 1,245 |
| 2019 | **349,256** | — |
| 2025 | **146,274** | 22,082 |
| 2026 | 0 | **175,920** |

`HiringPaths` is the populated column in 2017–2025. 2026 is the *sole* exception. The name carries no signal; only the data does. So the resolver counts non-nulls and takes the fullest candidate.

Resolution still happens in duckdb's namespace rather than pyarrow's, for the reason established in #578 — the file carries two columns differing only in case, SQL identifiers are case-insensitive, and emitting the parquet's name binds to the wrong column.

## Recovery is cheap

The 19 affected months need republishing, but nothing needs re-fetching: text is read back from the dataset and only the metadata join is redone.

## Tests

143 passing. The resolution tests now build all four real shapes — both-populated-one-sparse, capitalised-empty, single-spelling, and entirely-empty — and assert the picked column actually returns the data rather than just matching a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV