### PR TITLE
Skip the prune when there is no local text file to prune

### DIFF
--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -522,7 +522,9 @@ def main() -> int:
                        f"{len(manifest):,} total")
     print(f"\nPushed {len(written)} month(s) to {args.repo}")
 
-    if not args.keep_text:
+    # Nothing to prune when the text never was local -- a republish takes it
+    # from the dataset, so there is no file here to shrink.
+    if not args.keep_text and scraped.exists():
         cleared = prune_published_text(str(scraped), written_cns)
         after = os.path.getsize(scraped) / 1e6
         print(f"Dropped local text for {cleared:,} published postings; "


### PR DESCRIPTION
A republish takes its text from the dataset, so there's no scraped parquet on disk to shrink afterwards. The publish succeeded and the month was pushed — then the run died on `getsize()` for a file that doesn't exist, turning a clean republish into a non-zero exit.

Caught while rebuilding the 19 months affected by the null list columns in #582: each one pushed correctly and then reported a `FileNotFoundError`.

`prune_published_text` already guarded against the missing file; the size report after it did not.

143 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV