### PR TITLE
Let duckdb spill to disk instead of being OOM-killed on publish

### DIFF
--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -231,8 +231,25 @@ def parse_args():
 
 
 def connection():
+    """A duckdb connection that spills to disk rather than being OOM-killed.
+
+    The month COPY joins the historical mirror against twelve announcement-text
+    columns and sorts the result. A month is ~30k rows of ~40 KB of text, and
+    when a publish fails its text is not pruned, so the next attempt carries
+    both months: 58,426 rows, around 2.3 GB, before the sort materialises it
+    again. That took the process out three times on an 8 GB box, and each death
+    made the next attempt bigger.
+
+    memory_limit makes duckdb spill instead of dying, and temp_directory gives
+    it somewhere to spill to. The limit is well under the box's 8 GB because
+    the fetch workers and pyarrow need room alongside it.
+    """
     con = duckdb.connect()
     con.execute("INSTALL httpfs; LOAD httpfs; SET http_retries=5;")
+    spill = BUILD_DIR / "duckdb-spill"
+    spill.mkdir(parents=True, exist_ok=True)
+    con.execute(f"SET temp_directory='{spill}'")
+    con.execute(f"SET memory_limit='{os.environ.get('DUCKDB_MEMORY_LIMIT', '3GB')}'")
     return con
 
 
@@ -490,7 +507,9 @@ def main() -> int:
         con.execute(f"""
             COPY ({select_sql(con, str(hist), str(scraped), month, priors.get(month))}
                   ORDER BY usajobsControlNumber)
-            TO '{dest}' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 19);
+            -- level 19 buffers far more than it saves here; 12 is within a
+            -- few percent on this data and materially cheaper in memory.
+            TO '{dest}' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 12);
         """)
         rows = con.execute(
             f"SELECT count(*) FROM read_parquet('{dest}')").fetchone()[0]


### PR DESCRIPTION
Three more OOM kills — this time in the **publish**, not `compact`. And each death made the next attempt worse.

## The spiral

The month COPY joins the historical mirror against twelve announcement-text columns and sorts the result. A month is ~30k rows of ~40 KB of text.

When a publish dies, that month's text is never pruned. So the next attempt carries **both** months:

```
Local join has 58,426; 58,426 are new
Refreshing all 1 month(s)
usajobs-backfill.service: killed by the OOM killer
```

Roughly 2.3 GB before the sort materialises it again. Publish fails → text stays → next month piles on → publish fails harder. It had reached two months stacked and would have kept growing.

## Fix

`memory_limit` makes duckdb spill rather than die, and `temp_directory` gives it somewhere to spill to. 3 GB by default on an 8 GB box, since the fetch workers and pyarrow need room alongside it; `DUCKDB_MEMORY_LIMIT` overrides.

zstd drops from level 19 to 12 on the month files — 19 buffers far more than it saves on this data and was adding to the peak.

Breaking the spiral is the point: once a publish succeeds, its text is pruned and the next month starts from one month's worth again.

## Note on the previous OOM fix

#580 fixed `compact()` reading all shards at once, and that fix holds — `compact` isn't in any of these three tracebacks. This is a second, independent memory sink in the same run. Same symptom, different cause.

143 tests passing; verified a real month rebuild under the new settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV