### PR TITLE
Monitor progress instead of liveness, and stop a spiral at two failures

### DIFF
--- a/deploy/server.sh
+++ b/deploy/server.sh
@@ -88,9 +88,14 @@ cmd_status() {
   echo
   echo "Type $TYPE is billed hourly; 'destroy' stops the meter."
   local ip; ip=$(server_ip 2>/dev/null) || return 0
-  ssh -o ConnectTimeout=5 "root@$ip" \
-    'systemctl is-active usajobs-backfill 2>/dev/null || true' 2>/dev/null \
-    | sed 's/^/backfill service: /'
+  echo
+  # Deliberately not `systemctl is-active`. That reported "activating" for
+  # seven hours on 2026-09-06 while the run published nothing: it was failing,
+  # restarting cleanly, and carrying more text into each attempt. Progress is
+  # the signal, not liveness.
+  ssh -o ConnectTimeout=10 "root@$ip" \
+    "cd /srv/repos/usajobs_historical && ./.venv/bin/python scripts/backfill_status.py --hours ${STATUS_HOURS:-6}" \
+    2>/dev/null || echo "(could not read backfill status)"
 }
 
 cmd_logs() { ssh "root@$(server_ip)" 'journalctl -u usajobs-backfill -f -n 60'; }

--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -277,6 +277,12 @@ def months_awaiting_publish(data_dir, year):
     return [r[0] for r in rows]
 
 
+# Two failures in a row means the next attempt is carrying two months of
+# unpruned text into the join, and the one after that three. Stopping is the
+# only thing that does not make it worse.
+MAX_CONSECUTIVE_PUBLISH_FAILURES = 2
+
+
 def publish_month(data_dir, year, month):
     """Push one month to HuggingFace, which also drops its text from disk.
 
@@ -305,6 +311,8 @@ def publish_month(data_dir, year, month):
     if result.returncode != 0:
         print(f"  publish of {month} did not complete cleanly — its text "
               f"stays on disk and the next run retries it")
+        return False
+    return True
 
 
 def main() -> int:
@@ -428,6 +436,7 @@ def main() -> int:
             if len(batch) >= SHARD_ROWS:
                 flush()
 
+    consecutive_failures = 0
     for month, cns in sorted(by_month.items()):
         with ThreadPoolExecutor(max_workers=args.workers) as pool:
             list(tqdm(pool.map(work, cns), total=len(cns),
@@ -435,8 +444,23 @@ def main() -> int:
         flush()
         compact(args.data_dir, args.year)
         sys.stdout.flush()
-        if not args.no_publish:
-            publish_month(args.data_dir, args.year, month)
+        if args.no_publish:
+            continue
+
+        if publish_month(args.data_dir, args.year, month):
+            consecutive_failures = 0
+            continue
+
+        consecutive_failures += 1
+        if consecutive_failures >= MAX_CONSECUTIVE_PUBLISH_FAILURES:
+            # Carrying on from here only makes the next join bigger. On
+            # 2026-09-06 that spiral ran seven hours and published nothing
+            # while the service reported itself alive the whole time.
+            warn(f"Stopping {args.year}: {consecutive_failures} publishes "
+                 f"failed in a row, and each failure leaves a month's text "
+                 f"unpruned for the next one to carry. Fix the publish before "
+                 f"rerunning.")
+            return 1
 
     elapsed = (time.time() - started) / 60
     print(f"\nFetched {len(todo) - gone - failed:,} pages in {elapsed:.1f} min, "

--- a/scripts/backfill_status.py
+++ b/scripts/backfill_status.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Is the backfill actually making progress?
+
+Written because `systemctl is-active` said "activating" for seven hours while
+the run published nothing. The service was alive and restarting cleanly; it was
+just failing, pruning nothing, and carrying more text into each attempt until
+the OOM killer took it again. Liveness is not progress, and the only signal
+that would have caught it was the one nobody was watching.
+
+Three questions, in the order they go wrong:
+
+  Is it publishing?   Months pushed recently. Zero over a window that should
+                      hold several is the headline failure.
+  Is it spiralling?   A failed publish leaves its text unpruned, so the next
+                      attempt joins more rows than the last. "Local join has
+                      N" climbing across attempts is the signature, and it
+                      ends in the OOM killer every time.
+  Is it dying?        OOM kills and restarts in the window.
+
+Exit code is 0 when healthy and 1 when not, so it can drive an alert.
+
+    python backfill_status.py                # last 6 hours
+    python backfill_status.py --hours 24
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+# A month is 20k-31k postings, so a single month's join sits in that range.
+# Meaningfully above it means an earlier month's text was never pruned.
+SPIRAL_ROWS = 40_000
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Report backfill progress")
+    p.add_argument("--hours", type=float, default=6.0,
+                   help="Window to judge over (default 6)")
+    p.add_argument("--unit", default="usajobs-backfill")
+    return p.parse_args()
+
+
+def journal(unit, hours):
+    try:
+        out = subprocess.run(
+            ["journalctl", "-u", unit, "--no-pager", "-o", "cat",
+             "--since", f"-{hours} hours"],
+            capture_output=True, text=True, errors="replace", timeout=120)
+    except (OSError, subprocess.SubprocessError) as e:
+        sys.exit(f"could not read the journal: {e}")
+    return out.stdout.splitlines()
+
+
+def analyse(lines, hours):
+    """Journal lines -> (numbers, problems). Split out so the verdict is
+    testable without a systemd box to read from."""
+    published = [l for l in lines if "Pushed 1 month" in l]
+    ooms = [l for l in lines if "oom-kill" in l or "OOM killer" in l]
+    starts = [l for l in lines if "Starting usajobs" in l or l.startswith("=== ")]
+    joins = [int(m.group(1).replace(",", "")) for l in lines
+             if (m := re.search(r"Local join has ([\d,]+)", l))]
+    pages = [int(m.group(1).replace(",", "")) for l in lines
+             if (m := re.search(r"Fetched ([\d,]+) pages", l))]
+
+    stats = {"published": len(published), "pages": sum(pages),
+             "months_fetched": len(pages), "ooms": len(ooms),
+             "restarts": len(starts), "joins": joins}
+
+    problems = []
+    if not published:
+        problems.append(
+            f"nothing published in {hours:g}h — the service can be alive and "
+            f"restarting cleanly while publishing nothing at all")
+    if joins and max(joins) > SPIRAL_ROWS:
+        problems.append(
+            f"publish join reached {max(joins):,} rows, above {SPIRAL_ROWS:,} "
+            f"— a failed publish leaves its text unpruned and the next attempt "
+            f"carries both months")
+    if ooms:
+        problems.append(f"{len(ooms)} OOM kill(s)")
+    return stats, problems
+
+
+def main() -> int:
+    args = parse_args()
+    lines = journal(args.unit, args.hours)
+    if not lines:
+        print(f"No journal entries in the last {args.hours:g}h — is the unit "
+              f"named {args.unit}?")
+        return 1
+
+    stats, problems = analyse(lines, args.hours)
+    print(f"Last {args.hours:g} hours")
+    print(f"  months published   {stats['published']}")
+    print(f"  pages fetched      {stats['pages']:,} across "
+          f"{stats['months_fetched']} month(s)")
+    print(f"  OOM kills          {stats['ooms']}")
+    print(f"  run restarts       {stats['restarts']}")
+    if stats["joins"]:
+        print(f"  publish join rows  {stats['joins'][-1]:,} "
+              f"(max {max(stats['joins']):,})")
+
+    if problems:
+        print("\nNOT HEALTHY")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+
+    print("\nHealthy: publishing, no spiral, no OOM.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_backfill_status.py
+++ b/scripts/tests/test_backfill_status.py
@@ -1,0 +1,59 @@
+"""Tests for the backfill progress check.
+
+Written because `systemctl is-active` reported "activating" for seven hours
+while the run published nothing — it was failing, restarting cleanly, and
+carrying more unpruned text into each attempt until the OOM killer took it
+again. These assert the check notices what liveness could not.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from backfill_status import SPIRAL_ROWS, analyse
+
+
+def lines(published=0, joins=(), ooms=0, pages=()):
+    out = []
+    out += ["Pushed 1 month(s) to abigailhaddad/usajobs-scraping"] * published
+    out += [f"Local join has {n:,}; {n:,} are new" for n in joins]
+    out += ["usajobs-backfill.service: Failed with result 'oom-kill'."] * ooms
+    out += [f"Fetched {n:,} pages in 50.0 min, 0 failed" for n in pages]
+    return out
+
+
+class TestVerdict:
+    def test_a_publishing_run_is_healthy(self):
+        _, problems = analyse(lines(published=3, joins=(24_697,),
+                                    pages=(24_697,)), 6)
+        assert problems == []
+
+    def test_alive_but_publishing_nothing_is_caught(self):
+        # The exact failure: pages fetched, no months published.
+        _, problems = analyse(lines(published=0, pages=(31_041, 27_386)), 6)
+        assert len(problems) == 1
+        assert "nothing published" in problems[0]
+
+    def test_the_spiral_signature_is_caught(self):
+        # A failed publish leaves text unpruned, so the join grows past one
+        # month's worth. This is what preceded every OOM.
+        _, problems = analyse(lines(published=1, joins=(31_041, 58_426)), 6)
+        assert any("carries both months" in p for p in problems)
+
+    def test_one_month_of_join_rows_is_not_a_spiral(self):
+        _, problems = analyse(lines(published=2, joins=(31_041,)), 6)
+        assert not any("carries both" in p for p in problems)
+
+    def test_oom_kills_are_reported_even_when_publishing(self):
+        _, problems = analyse(lines(published=2, joins=(24_000,), ooms=1), 6)
+        assert any("OOM kill" in p for p in problems)
+
+    def test_counts_are_reported(self):
+        stats, _ = analyse(lines(published=4, joins=(20_000,), ooms=2,
+                                 pages=(24_697, 28_797)), 6)
+        assert stats["published"] == 4
+        assert stats["pages"] == 53_494
+        assert stats["ooms"] == 2
+
+    def test_the_spiral_threshold_sits_above_a_real_month(self):
+        # The largest month in the corpus is 2018-10 at 31,358.
+        assert SPIRAL_ROWS > 31_358


### PR DESCRIPTION
The publish spiral ran **seven hours and published nothing** while I checked `systemctl is-active` and read "activating" every time.

The service was alive and restarting cleanly. It was also failing, pruning no text, and carrying more rows into each attempt until the OOM killer took it. No process-state check could have caught that.

## The check that would have

`backfill_status.py` asks three questions, in the order they go wrong:

| question | signal | why |
|---|---|---|
| Is it publishing? | months pushed in the window | zero is the headline failure |
| Is it spiralling? | `Local join has N` above one month's worth | a failed publish leaves text unpruned; this preceded every OOM |
| Is it dying? | OOM kills, restarts | the consequence |

Exit 1 when unhealthy, so it can drive an alert. `server.sh status` now runs this instead of asking systemd whether a process exists.

`SPIRAL_ROWS` is 40,000 — above the largest real month in the corpus (2018-10 at 31,358) and well below two months stacked.

## And it can't spiral anymore

Two consecutive publish failures now stop the year. Carrying on only makes the next join bigger, and the failure needs a person either way — better to stop after two months than to find out after seven hours.

## Tests

150 passing, 7 new — including that "pages fetched, nothing published" is caught, that a growing join is caught, and that one normal month's join is *not* flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV