### PR TITLE
Drop the sort that exhausted duckdb, and fix the abort that crashed

### DIFF
--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -456,10 +456,11 @@ def main() -> int:
             # Carrying on from here only makes the next join bigger. On
             # 2026-09-06 that spiral ran seven hours and published nothing
             # while the service reported itself alive the whole time.
-            warn(f"Stopping {args.year}: {consecutive_failures} publishes "
-                 f"failed in a row, and each failure leaves a month's text "
-                 f"unpruned for the next one to carry. Fix the publish before "
-                 f"rerunning.")
+            print(f"STOPPING {args.year}: {consecutive_failures} publishes "
+                  f"failed in a row. Each failure leaves a month's text "
+                  f"unpruned for the next one to carry, so continuing only "
+                  f"makes the next join bigger. Fix the publish, then rerun.",
+                  flush=True)
             return 1
 
     elapsed = (time.time() - started) / 60

--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -249,7 +249,13 @@ def connection():
     spill = BUILD_DIR / "duckdb-spill"
     spill.mkdir(parents=True, exist_ok=True)
     con.execute(f"SET temp_directory='{spill}'")
-    con.execute(f"SET memory_limit='{os.environ.get('DUCKDB_MEMORY_LIMIT', '3GB')}'")
+    con.execute(f"SET memory_limit='{os.environ.get('DUCKDB_MEMORY_LIMIT', '4GB')}'")
+    # Both suggested by duckdb itself when it ran out at 2.7 GiB. Insertion
+    # order costs a full buffer of the result, and fewer threads means fewer
+    # concurrent buffers -- neither matters for a job that is IO-bound on the
+    # upload anyway.
+    con.execute("SET preserve_insertion_order=false")
+    con.execute(f"SET threads={os.environ.get('DUCKDB_THREADS', '2')}")
     return con
 
 
@@ -505,8 +511,11 @@ def main() -> int:
         # COPY streams straight to disk. Materializing a month in Python would
         # be ~800 MB of announcement text.
         con.execute(f"""
-            COPY ({select_sql(con, str(hist), str(scraped), month, priors.get(month))}
-                  ORDER BY usajobsControlNumber)
+            -- Deliberately unordered. ORDER BY forced duckdb to materialise
+            -- and sort ~2 GB of announcement text, which is what exhausted
+            -- the memory limit; row order in a parquet is not meaningful to
+            -- consumers and anyone who wants it can sort on read.
+            COPY ({select_sql(con, str(hist), str(scraped), month, priors.get(month))})
             -- level 19 buffers far more than it saves here; 12 is within a
             -- few percent on this data and materially cheaper in memory.
             TO '{dest}' (FORMAT parquet, COMPRESSION zstd, COMPRESSION_LEVEL 12);


### PR DESCRIPTION
Two bugs, both in code added hours ago.

## The publish still ran out of memory

But differently, and that difference matters: duckdb raised its **own** `OutOfMemoryException` at 2.7 GiB rather than being killed by the kernel. So `memory_limit` did work as a guard — it just couldn't finish the query. duckdb named the causes in its error and both applied.

The **`ORDER BY` was the main one**. Sorting forces the whole result to materialise, and the result is ~2 GB of announcement text. Row order in a parquet isn't meaningful to consumers and anyone who wants it can sort on read, so it's gone.

`preserve_insertion_order=false` and `threads=2` are the other two duckdb suggested — neither costs anything on a job that's IO-bound on the upload. The limit goes to 4 GB, still well under the box's 7.7 with only 1.2 in use.

## The spiral abort crashed instead of aborting

```
NameError: name 'warn' is not defined
--- 2018 exited 1
=== 2019 ===
```

It called `warn()`, which lives in `collect_scraped_data`, not there. So the abort raised, exited non-zero, and the year loop walked straight on to 2019 — exactly the behaviour it existed to prevent.

Worth naming plainly: **the guard against a long quiet failure was itself never executed**, because the only path that reaches it is the path where something has already gone wrong. It shipped four hours ago and its first run was its first test.

## Verified

A real month rebuild under the new settings: `2017-10`, 23,998 rows, 69.8 MB, no memory error.

150 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV