### PR TITLE
Judge the spiral on the current join, not the window's maximum

### DIFF
--- a/scripts/backfill_status.py
+++ b/scripts/backfill_status.py
@@ -73,9 +73,12 @@ def analyse(lines, hours):
         problems.append(
             f"nothing published in {hours:g}h — the service can be alive and "
             f"restarting cleanly while publishing nothing at all")
-    if joins and max(joins) > SPIRAL_ROWS:
+    # The latest join, not the largest. A spiral is a join that is big *now*;
+    # the maximum over the window keeps alarming long after it has unwound,
+    # which is how an alarm stops being worth reading.
+    if joins and joins[-1] > SPIRAL_ROWS:
         problems.append(
-            f"publish join reached {max(joins):,} rows, above {SPIRAL_ROWS:,} "
+            f"the last publish joined {joins[-1]:,} rows, above {SPIRAL_ROWS:,} "
             f"— a failed publish leaves its text unpruned and the next attempt "
             f"carries both months")
     if ooms:
@@ -99,8 +102,9 @@ def main() -> int:
     print(f"  OOM kills          {stats['ooms']}")
     print(f"  run restarts       {stats['restarts']}")
     if stats["joins"]:
-        print(f"  publish join rows  {stats['joins'][-1]:,} "
-              f"(max {max(stats['joins']):,})")
+        trend = "" if len(stats["joins"]) < 2 else \
+            f", was {stats['joins'][0]:,} at the start of the window"
+        print(f"  publish join rows  {stats['joins'][-1]:,} now{trend}")
 
     if problems:
         print("\nNOT HEALTHY")

--- a/scripts/tests/test_backfill_status.py
+++ b/scripts/tests/test_backfill_status.py
@@ -39,6 +39,13 @@ class TestVerdict:
         _, problems = analyse(lines(published=1, joins=(31_041, 58_426)), 6)
         assert any("carries both months" in p for p in problems)
 
+    def test_a_spiral_that_has_unwound_stops_alarming(self):
+        # The window still contains the old 58,426, but the last publish
+        # joined 2,000. Alarming on the maximum keeps a recovered run marked
+        # unhealthy for hours, which is how an alarm stops being read.
+        _, problems = analyse(lines(published=4, joins=(58_426, 27_385, 2_000)), 6)
+        assert not any("carries both" in p for p in problems)
+
     def test_one_month_of_join_rows_is_not_a_spiral(self):
         _, problems = analyse(lines(published=2, joins=(31_041,)), 6)
         assert not any("carries both" in p for p in problems)


### PR DESCRIPTION
The check kept reporting NOT HEALTHY after the spiral had unwound:

```
months published   4
OOM kills          0
publish join rows  2,000 (max 58,426)

NOT HEALTHY
  - publish join reached 58,426 rows...
```

Four months published, zero OOM kills, the last publish joining 2,000 rows — and still red, because the window also contained the old 58,426.

A spiral is a join that is big *now*. Taking the maximum keeps firing for hours after recovery, and an alarm that stays red once the problem is fixed is one people learn to ignore — which is the exact failure mode this check exists to avoid.

It now judges `joins[-1]` and prints the trend, so a genuine spiral shows as growth across attempts rather than a single number.

151 tests passing, including that a recovered spiral stops alarming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV