### PR TITLE
Give the backfill a memory ceiling instead of letting the kernel choose

### DIFF
--- a/deploy/install-backfill.sh
+++ b/deploy/install-backfill.sh
@@ -50,7 +50,16 @@ Type=oneshot
 User=$WORKER
 WorkingDirectory=$DIR
 EnvironmentFile=/etc/usajobs-backfill.env
+# duckdb spills past this rather than growing; well under MemoryMax so the
+# fetch workers and pyarrow have room beside it.
+Environment=DUCKDB_MEMORY_LIMIT=2GB
 ExecStart=$DIR/deploy/run-backfill.sh
+# Let the cgroup apply back-pressure and, at worst, kill just this service
+# rather than letting the kernel pick a victim. Two OOM kills in six hours on
+# 2026-09-07 were the kernel's doing at 7.7 GB; the publish never needed that
+# much, it simply had no ceiling to push back against.
+MemoryHigh=4G
+MemoryMax=6G
 # Every step is resumable, so restarting after a crash re-reads what is
 # already published and continues rather than redoing work.
 Restart=on-failure


### PR DESCRIPTION
Two OOM kills in six hours, both during a single month's publish — **not** a spiral this time, the join was one month at 31,495 rows.

The kernel killed the service at 7.7 GB because nothing bounded it. duckdb's own limit was 4 GB, but pyarrow and the parquet writer sit alongside it in the same run, and no cgroup ceiling existed to push back.

| setting | effect |
|---|---|
| `MemoryHigh=4G` | cgroup throttles and reclaims before anything dies |
| `MemoryMax=6G` | if something must be killed it's this service, not the kernel's pick |
| `DUCKDB_MEMORY_LIMIT=2GB` | duckdb spills to disk well before either |

The run already self-heals from these — publish-before-refetch means the month's text is on disk and gets published on restart rather than re-crawled, so each costs minutes rather than hours. This is about not spending those minutes.

Progress meanwhile: **46 of 117 months (39%)**, with 2017, 2018, 2019 and 2026 complete. 12 months published in the last 6 hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV