### PR TITLE
Give duckdb 3GB, not 2

### DIFF
--- a/deploy/install-backfill.sh
+++ b/deploy/install-backfill.sh
@@ -50,9 +50,10 @@ Type=oneshot
 User=$WORKER
 WorkingDirectory=$DIR
 EnvironmentFile=/etc/usajobs-backfill.env
-# duckdb spills past this rather than growing; well under MemoryMax so the
-# fetch workers and pyarrow have room beside it.
-Environment=DUCKDB_MEMORY_LIMIT=2GB
+# duckdb spills past this rather than growing, but it still needs room to
+# work: at 2GB it died at 1.8 GiB on an ordinary month publish that had been
+# fine at 4. 3GB sits under MemoryHigh with space for pyarrow beside it.
+Environment=DUCKDB_MEMORY_LIMIT=3GB
 ExecStart=$DIR/deploy/run-backfill.sh
 # Let the cgroup apply back-pressure and, at worst, kill just this service
 # rather than letting the kernel pick a victim. Two OOM kills in six hours on


### PR DESCRIPTION
2GB was too tight — duckdb died at 1.8 GiB on an ordinary month publish that had been completing fine at 4GB. Two of those in a row correctly tripped the stop-after-two-failures guard, which is the guard working as designed.

3GB sits under `MemoryHigh=4G` with room for pyarrow beside it. The ceiling is there to stop a runaway, not to starve the normal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV