### PR TITLE
Stop counting year markers as service restarts

### DIFF
--- a/scripts/backfill_status.py
+++ b/scripts/backfill_status.py
@@ -64,7 +64,11 @@ def analyse(lines, hours):
     testable without a systemd box to read from."""
     published = [l for l in lines if "Pushed 1 month" in l]
     ooms = [l for l in lines if "oom-kill" in l or "OOM killer" in l]
-    starts = [l for l in lines if "Starting usajobs" in l or l.startswith("=== ")]
+    # Only real service starts. "=== 2020 ===" is the year loop moving on,
+    # which is normal progress -- counting those as restarts reported 8 when
+    # there had been 2, and made a healthy run look like it was thrashing.
+    starts = [l for l in lines if "Starting usajobs" in l]
+    years = [l for l in lines if l.startswith("=== ")]
     joins = [int(m.group(1).replace(",", "")) for l in lines
              if (m := re.search(r"Local join has ([\d,]+)", l))]
     pages = [int(m.group(1).replace(",", "")) for l in lines
@@ -72,7 +76,7 @@ def analyse(lines, hours):
 
     stats = {"published": len(published), "pages": sum(pages),
              "months_fetched": len(pages), "ooms": len(ooms),
-             "restarts": len(starts), "joins": joins}
+             "restarts": len(starts), "years": len(years), "joins": joins}
 
     problems = []
     if not published:
@@ -109,10 +113,14 @@ def main() -> int:
     stats, problems = analyse(lines, args.hours)
     print(f"Last {args.hours:g} hours")
     print(f"  months published   {stats['published']}")
+    # Only completed months report a page count, so a month still in flight
+    # contributes nothing here. Zero with a healthy publish rate means the
+    # current month simply has not finished yet.
     print(f"  pages fetched      {stats['pages']:,} across "
-          f"{stats['months_fetched']} month(s)")
+          f"{stats['months_fetched']} completed month(s)")
     print(f"  OOM kills          {stats['ooms']}")
-    print(f"  run restarts       {stats['restarts']}")
+    print(f"  service restarts   {stats['restarts']}")
+    print(f"  years entered      {stats['years']}")
     if stats["joins"]:
         trend = "" if len(stats["joins"]) < 2 else \
             f", was {stats['joins'][0]:,} at the start of the window"

--- a/scripts/tests/test_backfill_status.py
+++ b/scripts/tests/test_backfill_status.py
@@ -85,3 +85,25 @@ class TestRate:
         _, problems = analyse(lines(published=0), 12)
         assert len(problems) == 1
         assert "nothing published" in problems[0]
+
+
+class TestRestartCounting:
+    """A year-loop marker is not a restart.
+
+    Counting "=== 2020 ===" as a restart reported 8 in a window that had 2,
+    which made a healthy run look like it was thrashing and sent me chasing a
+    loop that was not there.
+    """
+
+    def test_year_markers_are_not_restarts(self):
+        stats, _ = analyse(["=== 2018 ===", "=== 2019 ===", "=== 2020 ==="]
+                           + lines(published=4), 4)
+        assert stats["restarts"] == 0
+        assert stats["years"] == 3
+
+    def test_real_restarts_are_counted(self):
+        stats, _ = analyse(
+            ["Starting usajobs-backfill.service - USAJOBS backfill",
+             "=== 2020 ==="] + lines(published=4), 4)
+        assert stats["restarts"] == 1
+        assert stats["years"] == 1


### PR DESCRIPTION
The status check reported "8 restarts" in a window that had 2. It counted `=== 2020 ===` — the year loop moving on, ordinary progress — alongside real systemd starts.

That made a healthy run look like it was thrashing and sent me chasing a loop that wasn't happening. A monitoring tool that miscounts is worse than not having one, because it costs the time it was meant to save.

Also labels the page count as *completed* months. Only a finished month reports one, so a month in flight contributes nothing — zero pages alongside a healthy publish rate is normal, which was the other half of the same false picture.

13 tests passing on this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV