### PR TITLE
Skip reading the published text when the local copy already covers it

### DIFF
--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -485,6 +485,16 @@ def main() -> int:
             print(f"  {month}: {len(prior_cns):,} already published, "
                   f"{len(months.get(month, set()) - prior_cns):,} new")
             prior_sets[month] = prior_cns
+
+            # If the local scrape already covers everything the published file
+            # holds, the prior adds no text and only costs memory. Reading it
+            # anyway meant materialising the month's announcement text twice --
+            # ~1.2 GB each -- which is what drove the publish into constant
+            # spilling and took a month from minutes to nearly an hour.
+            if prior_cns and prior_cns <= months.get(month, set()):
+                print(f"    local copy covers all of it; skipping the "
+                      f"published text")
+                priors[month] = None
         availability[month] = months.get(month, set()) | prior_cns
 
     month_of = month_of_every_posting(con, str(hist))


### PR DESCRIPTION
A month publish had been running **56 minutes with 1.9 GB spilled to disk** — not hung, thrashing.

It was materialising the month's announcement text **twice**, about 1.2 GB each: once from the local scrape, once from the month file already on the dataset.

## Why the prior read exists, and why it's usually pointless

The prior file is read so text pruned locally can still be merged back. That's essential for a metadata-only republish.

But right after fetching a month, the local copy holds every row. The prior contributes nothing and costs a full second copy — and that's the common case, on every normal publish.

So when the published control numbers are a subset of what the local scrape has, the prior is skipped. It's still read whenever it might actually supply text: a republish, or a month gaining rows after its text was pruned.

## This explains the memory tuning

I'd been treating the 3 GB duckdb limit as too small and raising it. The limit wasn't wrong — the query was asking for twice what it needed. Raising the ceiling would have hidden that rather than fixed it.

160 tests passing; verified a real month rebuild still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV