### PR TITLE
Defer straggler months so restarts stop redoing finished years

### DIFF
--- a/deploy/run-backfill.sh
+++ b/deploy/run-backfill.sh
@@ -14,6 +14,11 @@ set -uo pipefail
 
 YEARS="${BACKFILL_YEARS:-2018 2019 2020 2021 2022 2023 2024 2025}"
 WORKERS="${BACKFILL_WORKERS:-6}"
+# A month is republished wholesale, so a year whose only outstanding work is a
+# few stragglers costs several full month rebuilds -- and pays that again on
+# every restart, before reaching any year with real work left. Deferred here
+# and swept up by a final pass.
+MIN_MONTH_WORK="${BACKFILL_MIN_MONTH_WORK:-200}"
 REPO="${REPO_DIR:-/srv/repos/usajobs_historical}"
 MIRROR="https://pub-317c58882ec04f329b63842c1eb65b0c.r2.dev/data"
 
@@ -36,6 +41,7 @@ for year in $YEARS; do
       --year "$year" \
       --known-from-hf \
       --workers "$WORKERS" \
+      --min-month-work "$MIN_MONTH_WORK" \
       --max-cpu 0 \
       --nice 0
   status=$?
@@ -43,6 +49,20 @@ for year in $YEARS; do
 
   # The year's text is on HuggingFace now and pruned locally; the mirror copy
   # is the only thing worth reclaiming.
+  rm -f "data/historical_jobs_${year}.parquet"
+done
+
+# Sweep: the deferred stragglers, now that the bulk is in.
+echo "=== sweeping deferred months ==="
+for year in $YEARS; do
+  if [ ! -s "data/historical_jobs_${year}.parquet" ]; then
+    curl -sSf --retry 5 --retry-delay 10 \
+      -o "data/historical_jobs_${year}.parquet" \
+      "$MIRROR/historical_jobs_${year}.parquet" || continue
+  fi
+  ./.venv/bin/python -u scripts/backfill_scraped_pages.py \
+      --year "$year" --known-from-hf --workers "$WORKERS" \
+      --max-cpu 0 --nice 0
   rm -f "data/historical_jobs_${year}.parquet"
 done
 

--- a/scripts/backfill_scraped_pages.py
+++ b/scripts/backfill_scraped_pages.py
@@ -73,6 +73,12 @@ def parse_args():
     p.add_argument("--nice", type=int, default=10,
                    help="Process niceness, 0-19 (default 10). Higher yields "
                         "more readily to whatever else is running.")
+    p.add_argument("--min-month-work", type=int, default=0,
+                   help="Skip months with fewer than this many pages to fetch. "
+                        "A month is republished wholesale, so rebuilding a "
+                        "28,000-row file for 3 stragglers costs minutes and "
+                        "happens again on every restart. Run a final pass at 0 "
+                        "to sweep them up.")
     p.add_argument("--known-from-hf", action="store_true",
                    help="Take the already-scraped set from the HuggingFace "
                         "manifest rather than the local parquet. That makes a "
@@ -397,6 +403,20 @@ def main() -> int:
     by_month = {}
     for cn in todo:
         by_month.setdefault(wanted[cn][:7], []).append(cn)
+
+    if args.min_month_work:
+        tiny = {m: c for m, c in by_month.items()
+                if len(c) < args.min_month_work}
+        if tiny:
+            # Each of these would rebuild and re-upload a whole month file for
+            # a few postings, and would do it again after the next restart.
+            print(f"  deferring {len(tiny)} month(s) with under "
+                  f"{args.min_month_work} pages: "
+                  + ", ".join(f"{m} ({len(c)})" for m, c in sorted(tiny.items())))
+            by_month = {m: c for m, c in by_month.items() if m not in tiny}
+        if not by_month:
+            print("  nothing above the threshold this year")
+            return 0
     print(f"  across {len(by_month)} month(s): "
           + ", ".join(f"{m} ({len(c):,})" for m, c in sorted(by_month.items())))
 


### PR DESCRIPTION
The run was republishing **2019 — already complete, 12 of 12** — at 4.4 GB of RSS, while 2020 through 2025 sat untouched.

## Why

A month file is rewritten wholesale, so a year whose only outstanding work is three postings still costs three full 28,000-row rebuilds and uploads.

And the year loop starts at 2018 on every service restart, so it pays that again each time. Three restarts today meant three passes over 2018 and 2019 before reaching a year with real work.

## Fix

Months with fewer than `--min-month-work` pages to fetch are deferred, and a sweep at the end of `run-backfill.sh` picks them up with no threshold once the bulk is done.

Default 200 — far below a real month (20,000–31,000) and far above a straggler (1–3).

## This also explains the memory picture

A republish *cannot* skip reading the published text, because the local copy was pruned after the original publish. So every straggler rebuild took the expensive double-read path that #597 just optimised away for normal publishes — which is why memory looked bad even after that fix.

160 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMReS4fLW72r2nCGYxgwDV