### PR TITLE
Do not block the installer on a job that runs for days

### DIFF
--- a/deploy/install-backfill.sh
+++ b/deploy/install-backfill.sh
@@ -86,7 +86,12 @@ WantedBy=multi-user.target
 UNIT
 
 systemctl daemon-reload
-systemctl enable --now usajobs-backfill.service
+# enable, then start --no-block. `enable --now` waits for ExecStart to finish,
+# and this is a Type=oneshot unit whose ExecStart is the whole backfill --
+# days. The install would sit there looking hung with the job running fine
+# behind it, which is exactly what it did on 2026-09-09.
+systemctl enable usajobs-backfill.service
+systemctl start --no-block usajobs-backfill.service
 
 echo
 echo "Started. Watch it with:"


### PR DESCRIPTION
Hit while moving the box from the `memory-thrash` branch back onto `main` after #600.

`systemctl enable --now` waits for `ExecStart` to complete. `usajobs-backfill` is `Type=oneshot` with `TimeoutStartSec=infinity`, and its `ExecStart` walks eight years of announcement pages — so the install command documented in `deploy/README.md` never returns. It sits there looking hung while the service behind it is running perfectly, which is the worst way for it to fail: the natural reaction is to interrupt it or re-run it.

Split into `enable` plus `start --no-block`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbpbtAHniNtbPKntXjiRqw
