### PR TITLE
Back-fill 2013-2016, and stop the completeness audit agreeing with the backfill

### DIFF
--- a/deploy/run-backfill.sh
+++ b/deploy/run-backfill.sh
@@ -23,7 +23,12 @@
 
 set -uo pipefail
 
-YEARS="${BACKFILL_YEARS:-2018 2019 2020 2021 2022 2023 2024 2025}"
+# Every year the historical mirror has, not just the ones that happened to be
+# listed here. This said 2018-2025 until 2026-09-11, and 2013-2016 was never
+# fetched as a result -- 4,048 postings, unnoticed because the completeness
+# audit defaulted to the same range and so could only ever agree with it.
+# A year with nothing to do costs one manifest read.
+YEARS="${BACKFILL_YEARS:-2013 2014 2015 2016 2017 2018 2019 2020 2021 2022 2023 2024 2025}"
 WORKERS="${BACKFILL_WORKERS:-6}"
 # Processes that parse pages. Empty means "one per core past the first", which
 # is 3 on a cx33. This is the throughput knob; WORKERS above is the request

--- a/scripts/audit_completeness.py
+++ b/scripts/audit_completeness.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Is the published dataset missing any announcements the mirror knows about?
+
+Compares every posting in the historical mirror against the dataset's manifest.
+The manifest is a couple of MB and the mirrors are ~40 MB a year, so this
+answers the question without downloading the dataset itself.
+
+    python audit_completeness.py                    # 2018-2025
+    python audit_completeness.py --years 2022 2023
+    python audit_completeness.py --probe            # also fetch what is missing
+
+Exit status is 0 when every gap is a known-unreachable announcement and 1 when
+something new is missing, so it can gate a workflow.
+
+Why the known-unreachable list exists: usajobs.gov serves 503 forever for 21
+announcements and 404 for one more. An audit that does not know this reports 22
+missing, and the obvious response -- rebuild those nineteen month files -- moves
+about 5 GB to add nothing, because a month file is rewritten whole and there is
+no text to put in it. See unreachable_announcements.csv.
+"""
+
+import argparse
+import csv
+import os
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+MIRROR = "https://pub-317c58882ec04f329b63842c1eb65b0c.r2.dev/data"
+HERE = os.path.dirname(os.path.abspath(__file__))
+UNREACHABLE = os.path.join(HERE, "unreachable_announcements.csv")
+
+
+def known_unreachable():
+    """Control numbers usajobs.gov refuses to serve, as {cn: status}."""
+    out = {}
+    if not os.path.exists(UNREACHABLE):
+        return out
+    with open(UNREACHABLE) as fh:
+        rows = csv.DictReader(line for line in fh if not line.startswith("#"))
+        for r in rows:
+            out[r["usajobs_control_number"]] = r["status"]
+    return out
+
+
+def mirror_path(year, cache_dir):
+    """The year's mirror, downloaded if this machine does not have it."""
+    import urllib.request
+    os.makedirs(cache_dir, exist_ok=True)
+    path = os.path.join(cache_dir, f"historical_jobs_{year}.parquet")
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        print(f"  downloading the {year} mirror", flush=True)
+        urllib.request.urlretrieve(f"{MIRROR}/historical_jobs_{year}.parquet", path)
+    return path
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    # 2013-2026, not the backfill's 2018-2025. Defaulting to the range the
+    # backfill happens to run makes the audit self-confirming: on 2026-09-11 it
+    # reported the dataset complete while 4,048 postings from 2013-2016 had
+    # never been fetched at all, because nothing had ever asked about them.
+    p.add_argument("--years", nargs="+", type=int,
+                   default=list(range(2013, 2027)))
+    p.add_argument("--cache-dir", default="data/mirror-cache",
+                   help="where year mirrors are kept between runs")
+    p.add_argument("--repo", default=os.environ.get(
+        "HF_DATASET_REPO", "abigailhaddad/usajobs-scraping"))
+    p.add_argument("--probe", action="store_true",
+                   help="fetch each missing announcement to see whether it is "
+                        "genuinely unreachable rather than merely unscraped")
+    args = p.parse_args()
+
+    import duckdb
+    from publish_to_huggingface import published_control_numbers
+    from huggingface_hub import get_token, list_repo_files
+
+    token = os.environ.get("HF_TOKEN") or get_token()
+    have = published_control_numbers(args.repo, token)
+    print(f"manifest: {len(have):,} announcements")
+
+    files = {os.path.basename(f)[:-len('.parquet')].replace("_", "-")
+             for f in list_repo_files(args.repo, repo_type="dataset", token=token)
+             if f.startswith("data/") and f.endswith(".parquet")}
+    month_files = sorted(m for m in files if len(m) == 7)
+    print(f"month files on the dataset: {len(month_files)} "
+          f"({month_files[0]} .. {month_files[-1]})")
+
+    con = duckdb.connect()
+    expected = defaultdict(set)
+    for year in args.years:
+        path = mirror_path(year, args.cache_dir)
+        rows = con.execute(f"""
+            SELECT usajobsControlNumber::varchar,
+                   substr(positionOpenDate, 1, 7)
+            FROM read_parquet('{path}')
+            WHERE positionOpenDate IS NOT NULL
+              AND usajobsControlNumber IS NOT NULL
+        """).fetchall()
+        # A mirror year holds postings whose open date lands outside it; each
+        # belongs to whichever year's audit covers its own month.
+        for cn, month in rows:
+            if month[:4] == str(year):
+                expected[month].add(cn)
+
+    # Deduplicated: a handful of control numbers carry a different open date in
+    # two mirror years and so appear under two months. Summing the per-month
+    # sets counts those twice and quietly inflates both the total and the
+    # published figure -- 124 of them across 2018-2025.
+    every = set()
+    for cns in expected.values():
+        every |= cns
+    total = len(every)
+    unreachable = known_unreachable()
+    gaps, unexplained, seen = [], [], set()
+    for month in sorted(expected):
+        for cn in sorted(expected[month] - have):
+            if cn in seen:
+                continue
+            seen.add(cn)
+            (gaps if cn in unreachable else unexplained).append((month, cn))
+
+    print(f"mirror postings: {total:,}")
+    print(f"published:       {total - len(gaps) - len(unexplained):,} "
+          f"({100 * (total - len(gaps) - len(unexplained)) / total:.4f}%)")
+    print(f"known unreachable: {len(gaps)}")
+    print(f"UNEXPLAINED:       {len(unexplained)}")
+
+    missing_files = [m for m in sorted(expected) if m not in files]
+    if missing_files:
+        print(f"\nmonths with no file on the dataset: {missing_files}")
+
+    if unexplained:
+        print("\nannouncements missing for no known reason:")
+        for month, cn in unexplained:
+            print(f"  {month}  {cn}")
+        if args.probe:
+            from usajobs_scrape import fetch_job_page, new_session
+            session = new_session()
+            print("\nprobing them:")
+            for month, cn in unexplained:
+                html, err = fetch_job_page(session, cn)
+                state = (f"OK {len(html):,} bytes" if html is not None
+                         else "404" if err is None else str(err)[:60])
+                print(f"  {month}  {cn}  {state}")
+            print("\nAnything that answers 503 or 404 consistently belongs in "
+                  "unreachable_announcements.csv. Check it against a known-good "
+                  "control number from the same month first: 21 pages failing "
+                  "at once looks exactly like rate limiting and is not.")
+
+    return 1 if (unexplained or missing_files) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_completeness.py
+++ b/scripts/audit_completeness.py
@@ -114,18 +114,31 @@ def main() -> int:
         every |= cns
     total = len(every)
     unreachable = known_unreachable()
-    gaps, unexplained, seen = [], [], set()
+    # The current year is still being collected, so a gap there means "not
+    # fetched yet", not "missing". Reported, but it does not fail the audit --
+    # otherwise this can never come back clean.
+    from datetime import date
+    current_year = str(date.today().year)
+    gaps, unexplained, in_flight, seen = [], [], [], set()
     for month in sorted(expected):
         for cn in sorted(expected[month] - have):
             if cn in seen:
                 continue
             seen.add(cn)
-            (gaps if cn in unreachable else unexplained).append((month, cn))
+            if cn in unreachable:
+                gaps.append((month, cn))
+            elif month[:4] == current_year:
+                in_flight.append((month, cn))
+            else:
+                unexplained.append((month, cn))
 
+    published = total - len(gaps) - len(unexplained) - len(in_flight)
     print(f"mirror postings: {total:,}")
-    print(f"published:       {total - len(gaps) - len(unexplained):,} "
-          f"({100 * (total - len(gaps) - len(unexplained)) / total:.4f}%)")
+    print(f"published:       {published:,} ({100 * published / total:.4f}%)")
     print(f"known unreachable: {len(gaps)}")
+    if in_flight:
+        print(f"{current_year} not yet collected: {len(in_flight)}  "
+              f"(the daily pipeline's, not a backfill gap)")
     print(f"UNEXPLAINED:       {len(unexplained)}")
 
     missing_files = [m for m in sorted(expected) if m not in files]

--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -303,13 +303,24 @@ def select_sql(con, hist_path: str, scraped_path: str, month: str,
 
     parts, union = [], ""
     if scraped_path and os.path.exists(scraped_path):
-        parts.append(f"""local_text AS (
+        # Select what the file has and null the rest, exactly as the prior file
+        # is handled below. save_jobs_to_parquet writes the keys the parsed
+        # pages happened to carry, so a column only exists if some posting in
+        # the file had it. With 30,000 postings a month something always does;
+        # with the six that 2014-10 holds, whole columns are simply absent and
+        # naming one is a binder error.
+        local_have = parquet_columns(scraped_path)
+        local_cols = ",\n        ".join(
+            c if c in local_have else f"CAST(NULL AS VARCHAR) AS {c}"
+            for c in TEXT_FIELDS)
+        if "text" in local_have:
+            parts.append(f"""local_text AS (
         SELECT usajobs_control_number AS cn,
-        {cols}
+        {local_cols}
         FROM read_parquet('{scraped_path}')
         WHERE text IS NOT NULL{local_day}
     )""")
-        union = "SELECT * FROM local_text"
+            union = "SELECT * FROM local_text"
     if prior_path:
         # A month published before a column existed does not have it. That is
         # the normal case on the first pass: every month on the dataset today

--- a/scripts/unreachable_announcements.csv
+++ b/scripts/unreachable_announcements.csv
@@ -4,7 +4,7 @@
 # from the same months, five seconds apart: every good page returned ~100 KB
 # and every one of these returned 503, which rules out rate limiting.
 #
-# They are the entire gap in the 2018-2025 backfill: 22 of 2,807,885.
+# They are the entire explained gap in 2013-2025: 25 of 3,049,079.
 #
 # Without this list an audit finds 22 missing announcements and the obvious
 # move is to rebuild all nineteen month files to add them -- about 2.5 GB of
@@ -34,3 +34,6 @@ usajobs_control_number,month,status,checked
 792728700,2024-05,503,2026-09-11
 811395400,2024-09,503,2026-09-11
 827765100,2025-01,503,2026-09-11
+469518400,2017-05,503,2026-09-11
+484918500,2017-11,503,2026-09-11
+485458400,2017-11,503,2026-09-11

--- a/scripts/unreachable_announcements.csv
+++ b/scripts/unreachable_announcements.csv
@@ -1,0 +1,36 @@
+# Announcements in the historical mirror that usajobs.gov will not serve, so
+# they are absent from the published dataset and always will be. Verified
+# 2026-09-11 by fetching each one interleaved with known-good control numbers
+# from the same months, five seconds apart: every good page returned ~100 KB
+# and every one of these returned 503, which rules out rate limiting.
+#
+# They are the entire gap in the 2018-2025 backfill: 22 of 2,807,885.
+#
+# Without this list an audit finds 22 missing announcements and the obvious
+# move is to rebuild all nineteen month files to add them -- about 2.5 GB of
+# download and the same again of upload, to add nothing. Measured: republishing
+# 2018-04 for its one missing posting took 141 seconds and wrote the same
+# 28,048 rows.
+usajobs_control_number,month,status,checked
+496112500,2018-04,503,2026-09-11
+510263200,2018-09,503,2026-09-11
+518254800,2018-11,503,2026-09-11
+520981300,2019-01,503,2026-09-11
+524719700,2019-02,503,2026-09-11
+524721000,2019-02,503,2026-09-11
+525043500,2019-02,503,2026-09-11
+525981200,2019-03,503,2026-09-11
+535373300,2019-05,503,2026-09-11
+547804400,2019-10,503,2026-09-11
+553566100,2019-12,503,2026-09-11
+569272000,2020-05,503,2026-09-11
+1282412,2020-07,404,2026-09-11
+573458100,2020-07,503,2026-09-11
+604259500,2021-06,503,2026-09-11
+668850500,2022-08,503,2026-09-11
+735923900,2023-07,503,2026-09-11
+779745400,2024-03,503,2026-09-11
+786265400,2024-04,503,2026-09-11
+792728700,2024-05,503,2026-09-11
+811395400,2024-09,503,2026-09-11
+827765100,2025-01,503,2026-09-11


### PR DESCRIPTION
The 2018–2025 backfill finished and looked complete. It wasn't.

`run-backfill.sh` hardcoded `YEARS="2018 ... 2025"`, so **2013–2016 was never fetched at all — 4,048 postings**, nearly all of them 2016.

What hid it is the part worth naming: the obvious range for a completeness check is the range the backfill runs, and **a check scoped to its own subject can only ever agree with it**. My first version of this audit defaulted to 2018–2025 and duly reported 99.9992% complete. So the audit now defaults to every year the mirror has (2013–2026), and `run-backfill.sh` lists them all too. A year with nothing left to do costs one manifest read.

Full picture across all mirror years:

| year | mirror | published | missing |
|---|---:|---:|---:|
| 2013 | 5 | 0 | **5** |
| 2014 | 24 | 0 | **24** |
| 2015 | 140 | 0 | **140** |
| 2016 | 3,879 | 0 | **3,879** |
| 2017 | 237,146 | 237,143 | 3 |
| 2018–2025 | 2,807,885 | 2,807,863 | 22 |
| 2026 | 180,044 | 179,879 | 165 |

2026's are current-year postings the daily pipeline is still working through.

## `audit_completeness.py`

Compares the mirror's control numbers against the dataset's manifest — a couple of MB plus ~40 MB a year, rather than the dataset itself. Exits non-zero when a gap has no known cause, so it can gate a workflow. `--probe` fetches whatever is unexplained.

## `unreachable_announcements.csv`

The 22 announcements usajobs.gov will not serve — 21 return 503 and one 404, every time, over days.

Verified by fetching them **interleaved with known-good control numbers from the same months, five seconds apart**: every good page returned ~100 KB and every one of these failed. That's what rules out rate limiting, which 21 simultaneous 503s otherwise look exactly like.

Without this list an audit reports 22 missing, and the obvious response is to rebuild those nineteen month files — ~5 GB of transfer to add nothing, since a month file is rewritten whole and there's no text to put in it. Measured: republishing 2018-04 for its one missing posting took 141 seconds and wrote back the same 28,048 rows.

Totals are deduplicated — a little over a hundred control numbers carry a different open date in two mirror years and appear under two months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbpbtAHniNtbPKntXjiRqw
