### PR TITLE
Make the deploy docs true, and fix two things the audit had never exercised

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ download/*.duckdb
 
 # Data files - Parquet and precomputed data (stored in Cloudflare R2, not in git)
 data/*.parquet
+# audit_completeness.py keeps the year mirrors here between runs: ~380 MB
+data/mirror-cache/
 # Baseline written by `sync_to_r2.py --snapshot`; local to a pipeline run.
 data/.r2_baseline.json
 web/data/*.parquet

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -42,10 +42,14 @@ ssh root@$IP 'bash -s' < deploy/install-backfill.sh
 
 ## Cost
 
-`cx33` (4 vCPU, 8 GB) is €9.99/month or €0.016/hour, **billed hourly**. The backlog is
-about four days of work, so running it and destroying the box costs roughly a
-euro or two. The monthly figure is a cap, not a commitment — check the exact
-price in the create form, and destroy the server when the work is done.
+`cx33` (4 vCPU, 8 GB) is €9.99/month or €0.016/hour, **billed hourly**. The
+monthly figure is a cap, not a commitment — check the exact price in the create
+form, and destroy the server when the work is done.
+
+For scale: the 2013–2026 announcement backfill was ~3.2M pages and cost about
+€2.50 of box time end to end, spread over six days. Most of those days were
+spent on the three bugs in **What cost us time** below rather than on fetching;
+at the rate it finished at, the work itself is closer to two.
 
 8 GB rather than 4 because `compact()` concatenates a month's shards in pandas
 and peaks near 1.6 GB.
@@ -62,7 +66,8 @@ hard ceiling of 4.8 regardless of `BACKFILL_WORKERS`. The old "8–9 pages/sec,
 four days" figure came from a developer laptop, which is 4.4x faster per core.
 
 Parsing now runs in a process pool (`--parse-workers`, default one per core
-past the first). Measured 4.41 → 9.67 pages/sec on the box.
+past the first). Measured 4.41 → 9.67 pages/sec in an A/B on the box, and it
+held 9.8–11 pages/sec in production for the rest of the backfill.
 
 lxml was tried and rejected: 129.5 ms/page against `html.parser`'s 113.4 here,
 and it changes parse output.
@@ -135,6 +140,42 @@ start — as one operation.
 **Anything unattended belongs on the box, not in an editor session.** Agent
 watches and timers die with the session that made them; a `systemd-run`
 transient unit does not.
+
+**Raising a memory limit moves the wall; it does not remove it.** duckdb ran
+out building a month of announcement text, and the budget had already been
+raised once for the same reason. The input keeps growing — months went from
+~31k postings in 2021 to 35–42k in 2022 — so the fix was to slice the work by
+day and stitch the pieces, which makes peak memory a property of the slice
+instead of the month. Reach for that the second time you raise a limit, not the
+fourth.
+
+**A check scoped to the thing it is checking can only agree with it.** The
+backfill ran a hardcoded 2018–2025 and the completeness audit defaulted to the
+same years, so it reported the dataset complete while 2013–2016 had never been
+fetched at all — 4,048 postings. Nothing was broken; the question was just never
+asked. Derive a check's scope from the source of truth, not from the job.
+
+**Schema is data-dependent when you write dicts.** `save_jobs_to_parquet` stores
+whatever keys the parsed pages carried, so a column exists only if some row had
+it. Across 30,000 rows something always does, and the code had never met a
+smaller input. At six rows whole columns are absent, and naming one is a binder
+error rather than a null. Anything that reads such a file should select what is
+there and fill the rest.
+
+## Checking the result
+
+`python scripts/audit_completeness.py` compares every posting in the historical
+mirror against the dataset's manifest and exits non-zero on a gap it cannot
+account for. It is the answer to "did the backfill actually finish", and it is
+cheap — a couple of MB for the manifest plus ~40 MB per year of mirror.
+
+`scripts/unreachable_announcements.csv` holds the postings usajobs.gov will not
+serve, so a clean run reports them rather than looking like a hole. Twenty-five
+as of 2026-09-11: twenty-four 503s and one 404, unchanged across days. Adding
+one costs a whole month-file rebuild for a single row, so confirm a gap is real
+before chasing it — and confirm it against a known-good control number from the
+same month, because a batch of simultaneous 503s looks exactly like rate
+limiting and is not.
 
 ## Adding another repo
 

--- a/scripts/audit_completeness.py
+++ b/scripts/audit_completeness.py
@@ -45,13 +45,37 @@ def known_unreachable():
 
 
 def mirror_path(year, cache_dir):
-    """The year's mirror, downloaded if this machine does not have it."""
+    """The year's mirror, downloaded if this machine does not have it.
+
+    The User-Agent is not decoration: R2 answers 403 to urllib's default.
+
+    Downloads to a temporary name and renames, so an interrupted run leaves no
+    truncated parquet for the next one to read as real. A half-written mirror
+    would under-report the postings that exist, which in this script means
+    silently claiming the dataset is more complete than it is.
+    """
     import urllib.request
     os.makedirs(cache_dir, exist_ok=True)
     path = os.path.join(cache_dir, f"historical_jobs_{year}.parquet")
-    if not os.path.exists(path) or os.path.getsize(path) == 0:
-        print(f"  downloading the {year} mirror", flush=True)
-        urllib.request.urlretrieve(f"{MIRROR}/historical_jobs_{year}.parquet", path)
+    if os.path.exists(path) and os.path.getsize(path) > 0:
+        return path
+
+    print(f"  downloading the {year} mirror", flush=True)
+    url = f"{MIRROR}/historical_jobs_{year}.parquet"
+    req = urllib.request.Request(url, headers={"User-Agent": "usajobs-audit/1.0"})
+    tmp = path + ".partial"
+    try:
+        with urllib.request.urlopen(req) as response, open(tmp, "wb") as fh:
+            while True:
+                chunk = response.read(1 << 20)
+                if not chunk:
+                    break
+                fh.write(chunk)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
     return path
 
 

--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -344,6 +344,14 @@ def select_sql(con, hist_path: str, scraped_path: str, month: str,
     )""")
         union += (" UNION ALL " if union else "") + "SELECT * FROM prior_text"
 
+    if not parts:
+        # No local text and no published file: there is nothing to build this
+        # month from. Say so, rather than emitting SQL with an empty WITH and
+        # letting duckdb report a syntax error several frames away.
+        raise ValueError(
+            f"no text available for {month}: the local scrape has none and "
+            f"the dataset has no file for it")
+
     text_cols = ",\n    ".join(f"t.{c}" for c in TEXT_FIELDS)
     return f"""
         WITH {wanted_cte}{", ".join(parts)}, txt AS ({union})


### PR DESCRIPTION
Tidying pass now the backfill is finished. Two of these are real bugs.

## The audit could not download a mirror

R2 answers **403 Forbidden** to urllib's default User-Agent. Every run so far had a cache I'd populated by hand, so the one path a new user would actually take was the only one never exercised.

It now sends a User-Agent like `download_data.py` does, and writes to a temporary name before renaming — an interrupted run was otherwise free to leave a truncated parquet that the next run reads as real, under-reporting the postings that exist and so *overstating* how complete the dataset is. Verified from a cold cache: downloads, caches on the second call, leaves no `.partial`, and the file reads back.

## The audit's cache was not ignored

`data/mirror-cache/` holds ~380 MB of year mirrors and `data/*.parquet` does not match a subdirectory, so a normal run would have staged them for commit.

## `select_sql` could emit SQL with an empty `WITH`

Making the local side optional — so a month whose scrape has no `text` column can still publish — introduced a way to reach "no text source at all". That produced a binder error several frames from the cause. It now raises with the month named.

## Docs

- **Cost** still described the backlog as four days of unknown work. It now carries what the finished job cost: ~3.2M pages, ~€2.50, six days, most of them spent on bugs rather than fetching.
- **Rate** gets the sustained production number (9.8–11 pages/sec) beside the A/B.
- **Three lessons the doc predates**: raising a memory limit moves the wall rather than removing it; a check scoped to the thing it checks can only agree with it; schema is data-dependent when you write dicts.
- **A "Checking the result" section** pointing at `audit_completeness.py`, since "did it actually finish" is the question a reader arrives with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbpbtAHniNtbPKntXjiRqw
