### PR TITLE
Pin the published column types, and tell a refused month from a broken one

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -473,11 +473,23 @@ jobs:
         # only republishes the months that gained rows.
         REFRESH=""
         [ "$(date -u +%d)" = "01" ] && REFRESH="--refresh-all"
-        # Never fails the run: the dataset is downstream of everything that
-        # matters here, and publish_to_huggingface.py exits non-zero when it
-        # refuses a month rather than shrink it.
-        python scripts/publish_to_huggingface.py $REFRESH || \
-          echo "::warning::HuggingFace publish did not complete cleanly"
+        # A refused month (exit 3) is expected while a backfill is still
+        # filling in text, and the dataset is downstream of everything that
+        # matters here -- so that only warns. Anything else non-zero means
+        # nothing was published at all: a column type that drifted, or a
+        # traceback. Those used to be swallowed by the same `||` and showed up
+        # as an annotation nobody reads, which is how six month files sat on
+        # the dataset with the wrong types for years.
+        set +e
+        python scripts/publish_to_huggingface.py $REFRESH
+        status=$?
+        set -e
+        if [ "$status" = "3" ]; then
+          echo "::warning::HuggingFace publish refused a month rather than shrink it"
+        elif [ "$status" != "0" ]; then
+          echo "::error::HuggingFace publish failed (exit $status) — nothing was published"
+          echo "HF_PUBLISH_FAILED=1" >> "$GITHUB_ENV"
+        fi
 
     - name: Commit and push to data-updates branch
       # Only runs if tests pass
@@ -640,6 +652,17 @@ jobs:
         exit 1
       env:
         GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+    # Deferred to here rather than failing the publish step itself: none of
+    # the steps between have `if: always()`, so exiting up there would skip the
+    # R2 sync, the PR and the site update, all of which are independent of
+    # HuggingFace. Sits before "Check for failures" so that step's `failure()`
+    # still sees a failed job and opens the issue.
+    - name: Fail the run if the HuggingFace publish failed
+      if: always() && env.HF_PUBLISH_FAILED == '1'
+      run: |
+        echo "The HuggingFace publish did not complete — see the error above."
+        exit 1
 
     - name: Check for failures
       if: failure() || (env.CHANGES_MADE == 'true' && steps.data_tests.outcome == 'failure')

--- a/scripts/publish_to_huggingface.py
+++ b/scripts/publish_to_huggingface.py
@@ -48,9 +48,8 @@ BUILD_DIR = Path(__file__).resolve().parent.parent / "build" / "hf"
 # inserted_at / last_seen, bookkeeping for this pipeline's own collection runs;
 # backfilled, which only exists in 2024 and 2025.
 #
-# whoMayApply is cast because it is VARCHAR through 2024 and an empty INTEGER
-# from 2025. Without the cast the published month files disagree on its type
-# and the dataset cannot be read as a whole.
+# Every column is cast to the type it is published as; see NON_STRING_COLUMNS
+# for why, and for the six files that were published before it was.
 #
 # The list-valued columns are resolved per file rather than named here; see
 # resolve_list_columns for why nothing about the name is trustworthy.
@@ -103,28 +102,75 @@ def resolve_list_columns(con, hist_path):
     return out
 
 
+# The type every published column must have, for anything not VARCHAR.
+#
+# Enforced rather than assumed because duckdb types a column of untyped NULLs
+# as INT32, so a month where a metadata field happens to be entirely empty
+# publishes a different type for it than every other month does.
+#
+# Not hypothetical. whoMayApply went out as INT32 for 2026-01, -03, -04 and -05
+# before the cast below existed, and hiringSubelementName, serviceType and the
+# two announcementClosingType columns went out as unannotated BYTE_ARRAY for
+# 2013-09 and 2013-10, whose one and six rows leave them null.
+#
+# What that costs: arrow unifies string and binary to binary, and the 2013
+# files sort first, so all four of those columns read back as *bytes* for
+# everyone using the dataset -- which is what the HuggingFace viewer reports
+# for them. datasets-server has also been unable to build its index for this
+# dataset ("the dataset index is loading", then "the dataset index is corrupted
+# and being rebuilt"), which takes filter and search down; whether the drift is
+# the cause of that is unproven, but it is the only schema defect the dataset
+# has.
+# A refused month is an expected state, not a fault: it is what the guard does
+# while backfill_scraped_pages.py is still filling in a month's text, and the
+# daily workflow should note it and move on. Every other non-zero exit -- a
+# column type that drifted, an unhandled traceback -- means nothing was
+# published at all, which is worth waking someone for. Giving refusal its own
+# code is what lets the workflow tell those apart; exit 1 stays the loud one
+# because that is what an uncaught exception exits with.
+EXIT_REFUSED = 3
+
+
+NON_STRING_COLUMNS = {
+    "agencyLevel": "BIGINT",
+    "minimumSalary": "DOUBLE",
+    "maximumSalary": "DOUBLE",
+}
+
+
+def typed(column):
+    """`h.x` cast to the type x is published as."""
+    return (f"CAST(h.{column} AS {NON_STRING_COLUMNS.get(column, 'VARCHAR')}) "
+            f"AS {column}")
+
+
 def metadata_fields(con, hist_path):
     cols = resolve_list_columns(con, hist_path)
+    # Order is the dataset's existing column order; the dates sit in the
+    # middle of it, so the pass-through columns come in two runs around them.
+    before = ",\n    ".join(typed(c) for c in (
+        "positionTitle", "announcementNumber",
+        "hiringAgencyCode", "hiringAgencyName",
+        "hiringDepartmentCode", "hiringDepartmentName", "hiringSubelementName",
+        "agencyLevel", "agencyLevelSort",
+        "appointmentType", "workSchedule", "serviceType", "whoMayApply",
+        "payScale", "salaryType", "minimumSalary", "maximumSalary",
+        "minimumGrade", "maximumGrade", "promotionPotential",
+        "supervisoryStatus", "totalOpenings", "positionOpeningStatus",
+        "announcementClosingTypeCode", "announcementClosingTypeDescription",
+    ))
+    after = ",\n    ".join(typed(c) for c in (
+        "travelRequirement", "teleworkEligible", "relocationExpensesReimbursed",
+        "securityClearanceRequired", "securityClearance", "drugTestRequired",
+        "disableApplyOnline", "vendor",
+    ))
     return f"""
     h.usajobsControlNumber::varchar AS usajobsControlNumber,
-    h.positionTitle,
-    h.announcementNumber,
-    h.hiringAgencyCode, h.hiringAgencyName,
-    h.hiringDepartmentCode, h.hiringDepartmentName,
-    h.hiringSubelementName,
-    h.agencyLevel, h.agencyLevelSort,
-    h.appointmentType, h.workSchedule, h.serviceType,
-    CAST(h.whoMayApply AS VARCHAR) AS whoMayApply,
-    h.payScale, h.salaryType, h.minimumSalary, h.maximumSalary,
-    h.minimumGrade, h.maximumGrade, h.promotionPotential, h.supervisoryStatus,
-    h.totalOpenings, h.positionOpeningStatus,
-    h.announcementClosingTypeCode, h.announcementClosingTypeDescription,
+    {before},
     substr(h.positionOpenDate, 1, 10)   AS positionOpenDate,
     substr(h.positionCloseDate, 1, 10)  AS positionCloseDate,
     substr(h.positionExpireDate, 1, 10) AS positionExpireDate,
-    h.travelRequirement, h.teleworkEligible, h.relocationExpensesReimbursed,
-    h.securityClearanceRequired, h.securityClearance, h.drugTestRequired,
-    h.disableApplyOnline, h.vendor,
+    {after},
     {cols['hiringPaths']}        AS hiringPaths,
     {cols['jobCategories']}      AS jobCategories,
     {cols['positionLocations']}  AS positionLocations,
@@ -311,7 +357,8 @@ def select_sql(con, hist_path: str, scraped_path: str, month: str,
         # naming one is a binder error.
         local_have = parquet_columns(scraped_path)
         local_cols = ",\n        ".join(
-            c if c in local_have else f"CAST(NULL AS VARCHAR) AS {c}"
+            f"CAST({c} AS VARCHAR) AS {c}" if c in local_have
+            else f"CAST(NULL AS VARCHAR) AS {c}"
             for c in TEXT_FIELDS)
         if "text" in local_have:
             parts.append(f"""local_text AS (
@@ -329,7 +376,8 @@ def select_sql(con, hist_path: str, scraped_path: str, month: str,
         # up for the UNION.
         available = parquet_columns(prior_path)
         prior_cols = ",\n        ".join(
-            c if c in available else f"CAST(NULL AS VARCHAR) AS {c}"
+            f"CAST({c} AS VARCHAR) AS {c}" if c in available
+            else f"CAST(NULL AS VARCHAR) AS {c}"
             for c in TEXT_FIELDS)
         exclude = ("WHERE usajobsControlNumber NOT IN (SELECT cn FROM local_text)"
                    if union else "")
@@ -436,6 +484,27 @@ def stitch(parts, dest):
     finally:
         if writer is not None:
             writer.close()
+
+
+def check_types(path):
+    """Refuse to upload a month whose columns are not the published types.
+
+    The casts in metadata_fields are what keep this true. This is what turns a
+    future edit that drops one of them into a failed build rather than a
+    dataset that silently stops being indexable -- the failure mode is invisible
+    from here, since every month reads fine on its own and only the union of
+    them breaks.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    arrow = {"BIGINT": pa.int64(), "DOUBLE": pa.float64()}
+    wrong = [f"{f.name} is {f.type}, expected {want}"
+             for f in pq.read_schema(path)
+             for want in [arrow.get(NON_STRING_COLUMNS.get(f.name), pa.string())]
+             if f.type != want]
+    if wrong:
+        raise SystemExit(f"{path} has the wrong column types, refusing to "
+                         f"publish it: " + "; ".join(wrong))
 
 
 def download_month(repo, month, token):
@@ -630,7 +699,7 @@ def main() -> int:
 
     if not todo:
         print("Nothing to publish")
-        return 1 if refused else 0
+        return EXIT_REFUSED if refused else 0
 
     BUILD_DIR.mkdir(parents=True, exist_ok=True)
     written = []
@@ -675,6 +744,7 @@ def main() -> int:
             con.execute(
                 f"COPY ({select_sql(con, str(hist), str(scraped), month, priors.get(month))}) "
                 f"TO '{dest}' {copy_opts};")
+        check_types(dest)
         rows = con.execute(
             f"SELECT count(*) FROM read_parquet('{dest}')").fetchone()[0]
         print(f"  {name}: {rows:,} rows, {dest.stat().st_size/1e6:.1f} MB")
@@ -713,7 +783,7 @@ def main() -> int:
         print(f"Dropped local text for {cleared:,} published postings; "
               f"{scraped.name} is now {after:,.0f} MB")
 
-    return 1 if refused else 0
+    return EXIT_REFUSED if refused else 0
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_publish_hf.py
+++ b/scripts/tests/test_publish_hf.py
@@ -12,7 +12,9 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-from publish_to_huggingface import (TEXT_FIELDS, metadata_fields,
+from publish_to_huggingface import (EXIT_REFUSED, NON_STRING_COLUMNS,
+                                    TEXT_FIELDS,
+                                    check_types, metadata_fields,
                                     partition_safe_months,
                                     prune_published_text, resolve_list_columns)
 
@@ -215,8 +217,8 @@ class TestPublishedSchema:
         # The field list this replaced omitted positionTitle, so the published
         # dataset had no job title in it at all.
         fields = self._fields(tmp_path)
-        assert "h.positionTitle," in fields
-        assert "h.hiringSubelementName," in fields
+        assert "AS positionTitle" in fields
+        assert "AS hiringSubelementName" in fields
 
     def test_bookkeeping_columns_are_not_published(self, tmp_path):
         fields = self._fields(tmp_path)
@@ -229,11 +231,86 @@ class TestPublishedSchema:
         # month files disagree and the dataset cannot be read as a whole.
         assert "CAST(h.whoMayApply AS VARCHAR)" in self._fields(tmp_path)
 
+    def test_every_metadata_column_is_cast(self, tmp_path):
+        # Not just whoMayApply. duckdb types a column of untyped NULLs as
+        # INT32, so any metadata field that happens to be empty for a month
+        # publishes the wrong type for that month unless it is cast.
+        fields = self._fields(tmp_path)
+        for column in ("hiringSubelementName", "serviceType",
+                       "announcementClosingTypeCode",
+                       "announcementClosingTypeDescription", "totalOpenings"):
+            assert f"CAST(h.{column} AS VARCHAR)" in fields
+
+    def test_the_numeric_columns_stay_numeric(self, tmp_path):
+        fields = self._fields(tmp_path)
+        assert "CAST(h.agencyLevel AS BIGINT)" in fields
+        assert "CAST(h.minimumSalary AS DOUBLE)" in fields
+        assert "CAST(h.maximumSalary AS DOUBLE)" in fields
+
     def test_every_announcement_section_is_published(self):
         for section in ("jobSummary", "majorDuties", "qualificationSummary",
                         "education", "requiredDocuments", "howToApply", "text"):
             assert section in TEXT_FIELDS
         assert len(TEXT_FIELDS) == 12
+
+
+class TestCheckTypes:
+    """The guard that refuses to upload a month with drifted column types.
+
+    whoMayApply shipped as INT32 for four 2026 months and four other columns
+    shipped as unannotated binary for the two 2013 months, because each was
+    entirely null there and nothing pinned the type. Every one of those files
+    reads fine alone -- only the union of them is wrong, which is why it went
+    unnoticed for years.
+    """
+    def _write(self, tmp_path, columns):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+        path = tmp_path / "m.parquet"
+        pq.write_table(pa.table(columns), path)
+        return path
+
+    def _good(self):
+        import pyarrow as pa
+        return {"usajobsControlNumber": pa.array(["1"], pa.string()),
+                "whoMayApply": pa.array([None], pa.string()),
+                "agencyLevel": pa.array([2], pa.int64()),
+                "minimumSalary": pa.array([1.0], pa.float64())}
+
+    def test_the_published_types_pass(self, tmp_path):
+        check_types(self._write(tmp_path, self._good()))
+
+    def test_an_all_null_string_column_typed_as_int_is_refused(self, tmp_path):
+        import pyarrow as pa
+        columns = self._good()
+        columns["whoMayApply"] = pa.array([None], pa.int32())
+        with pytest.raises(SystemExit, match="whoMayApply"):
+            check_types(self._write(tmp_path, columns))
+
+    def test_binary_is_refused_too(self, tmp_path):
+        # The 2013 flavour: BYTE_ARRAY with no UTF8 annotation.
+        import pyarrow as pa
+        columns = self._good()
+        columns["serviceType"] = pa.array([None], pa.binary())
+        with pytest.raises(SystemExit, match="serviceType"):
+            check_types(self._write(tmp_path, columns))
+
+    def test_a_numeric_column_turned_string_is_refused(self, tmp_path):
+        import pyarrow as pa
+        columns = self._good()
+        columns["agencyLevel"] = pa.array(["2"], pa.string())
+        with pytest.raises(SystemExit, match="agencyLevel"):
+            check_types(self._write(tmp_path, columns))
+
+    def test_every_non_string_column_is_one_duckdb_can_cast_to(self):
+        assert set(NON_STRING_COLUMNS.values()) <= {"BIGINT", "DOUBLE"}
+
+    def test_refusal_has_its_own_exit_code(self):
+        # The daily workflow warns on a refused month and fails on anything
+        # else, so refusal must not collide with 0 or with the 1 an uncaught
+        # exception exits with -- a drifted type has to stay distinguishable
+        # from "backfill is still running".
+        assert EXIT_REFUSED not in (0, 1)
 
 
 class TestPrunePublishedText:


### PR DESCRIPTION
Six of the 152 month files on the HuggingFace dataset disagreed with the rest about what type four columns are:

| files | column(s) | type there | type in the other 146 |
|---|---|---|---|
| `2026_01`, `2026_03`, `2026_04`, `2026_05` | `whoMayApply` | INT32 | UTF8 string |
| `2013_09`, `2013_10` | `hiringSubelementName`, `serviceType`, `announcementClosingTypeCode`, `announcementClosingTypeDescription` | BYTE_ARRAY, no UTF8 annotation | UTF8 string |

## Why

duckdb types a column of untyped NULLs as INT32:

```
COPY (SELECT NULL AS untyped, CAST(NULL AS VARCHAR) AS typed) TO 'x.parquet'
→ untyped: INT32 / INT_32
   typed:  BYTE_ARRAY / UTF8
```

Those columns are entirely null in those months — `2013_09` has one row — so whatever the mirror handed over went straight through. The `whoMayApply` cast in 4d18fff2 fixed the code; the four files already on the dataset were never rewritten.

**What it cost:** arrow unifies string and binary to binary, and `2013_09` sorts first, so all four of those columns read back as *bytes* rather than text for everyone using the dataset. The HuggingFace viewer reported `dtype: binary` for them. It now reports `string`.

## What changed

- `NON_STRING_COLUMNS` + `typed()` cast every metadata column to the type it is published as; the 12 `TEXT_FIELDS` are cast too, since an all-null section in a small month drifts the same way. Column order is unchanged.
- `check_types()` runs after each month is built and refuses to upload one whose columns drifted.
- A refused month now exits 3 and the daily workflow still only warns, since that is the expected state while a backfill is filling in text. Anything else fails the run. That failure is deferred to a late gate step, because none of the steps between have `if: always()` and the R2 sync, the PR and the site update have nothing to do with HuggingFace.

## Already done outside this PR

All six months are republished, row counts unchanged (16,173 / 23,121 / 23,840 / 21,894 / 1 / 4), and a schema scan across all 152 files now finds no type conflicts.

## Not established

Whether any of this is what has been stopping datasets-server from building its index. Mixed types did not make pyarrow fail when tested, and `/filter` was still erroring at the time of writing. It was the only schema defect the dataset had.

Separately and not fixable here: `/statistics` fails inside HuggingFace's own histogram code for `agencyLevel`, whose only values are 1 and 2.

## Testing

167 tests pass, including 6 new ones covering the guard and the exit code. Verified end to end by building a mirror with the exact broken shape (binary nulls, INT32 `whoMayApply`, `pa.null()` columns): all 41 metadata columns come out string/int64/double.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbpbtAHniNtbPKntXjiRqw